### PR TITLE
Add IPv6 configuration

### DIFF
--- a/backups/routers/cycletrailer.noisebridge.net
+++ b/backups/routers/cycletrailer.noisebridge.net
@@ -95,7 +95,7 @@ interfaces {
             pd 1 {
                 interface eth0 {
                     host-address ::1
-                     no-dns
+                    no-dns
                     prefix-id 1
                     service dhcpv6-stateless
                 }

--- a/backups/routers/cycletrailer.noisebridge.net
+++ b/backups/routers/cycletrailer.noisebridge.net
@@ -1,6 +1,76 @@
+firewall {
+    ipv6-name WAN_IN_v6 {
+        default-action drop
+        description "WAN to LAN (IPv6)"
+        rule 10 {
+            action accept
+            description ICMPv6
+            log disable
+            protocol icmpv6
+        }
+        rule 20 {
+            action accept
+            description "Allow established"
+            protocol all
+            log disable
+            state {
+                established enable
+                related enable
+            }
+        }
+        rule 21 {
+            action drop
+            description "Drop invalid"
+            protocol all
+            log disable
+            state {
+                invalid enable
+            }
+        }
+    }
+    ipv6-name WAN_LOCAL_v6 {
+        default-action drop
+        description "WAN to router (IPv6)"
+        rule 10 {
+            action accept
+            description ICMPv6
+            log disable
+            protocol icmpv6
+        }
+        rule 20 {
+            action accept
+            description "Allow established"
+            protocol all
+            log disable
+            state {
+                established enable
+                related enable
+            }
+        }
+        rule 21 {
+            action drop
+            description "Drop invalid"
+            protocol all
+            log disable
+            state {
+                invalid enable
+            }
+        }
+        rule 30 {
+            action accept
+            description DHCPv6
+            log disable
+            destination {
+                port 546,547
+            }
+            protocol udp
+        }
+    }
+}
 interfaces {
     ethernet eth0 {
         address 10.20.0.1/16
+        address fd95:0c38:25f0::1/64
         description "NB LAN"
         duplex auto
         speed auto
@@ -14,10 +84,34 @@ interfaces {
         address 192.195.83.134/29
         address 192.195.83.133/29
         address 10.19.0.1/24
+        address fd95:0c38:25f0:1::1/64
         description "MonkeyBrains WAN"
         duplex auto
         ip {
             enable-proxy-arp
+        }
+        dhcpv6-pd {
+            no-dns
+            pd 1 {
+                interface eth0 {
+                    host-address ::1
+                     no-dns
+                    prefix-id 1
+                    service dhcpv6-stateless
+                }
+                prefix-length 56
+            }
+            rapid-commit enable
+        }
+        firewall {
+            in {
+                ipv6-name WAN_IN_v6
+                name WAN_IN
+            }
+            local {
+                ipv6-name WAN_LOCAL_v6
+                name WAN_LOCAL
+            }
         }
         speed auto
     }
@@ -117,12 +211,23 @@ service {
         }
         use-dnsmasq enable
     }
+    dhcpv6-server {
+        shared-network-name lan {
+                name-server fd95:0c38:25f0::1
+                subnet fd95:0c38:25f0::/48 {
+                        domain-search noise
+                }
+        }
+    }
     dns {
         forwarding {
             cache-size 9000
             listen-on eth0
+            listen-on eth2
             name-server 8.8.8.8
             name-server 8.8.4.4
+            name-server 2001:4860:4860::8888
+            name-server 2001:4860:4860::8844
         }
     }
     nat {

--- a/backups/routers/cycletrailer.noisebridge.net
+++ b/backups/routers/cycletrailer.noisebridge.net
@@ -201,8 +201,6 @@ service {
         shared-network-name uplink {
             subnet 10.19.0.0/24 {
                 default-router 10.19.0.1
-                dns-server 10.19.0.1
-                domain-name noise
                 static-mapping roofswitch.noise {
                     ip-address 10.19.0.5
                     mac-address dc:9f:db:28:de:6d
@@ -223,7 +221,6 @@ service {
         forwarding {
             cache-size 9000
             listen-on eth0
-            listen-on eth2
             name-server 8.8.8.8
             name-server 8.8.4.4
             name-server 2001:4860:4860::8888


### PR DESCRIPTION
This is what I adapted from my own IPv6 configuration.
Main points:
1. Gets a /56 prefix and sets up router advertisements for stateless autoconfiguration (SLAAC) on eth0. 
1. Creates a basic firewall rule for inbound traffic that allows established/related traffic through + ICMPv6. The inbound to router rule additionally allows DHCPv6 ports through or DHCPv6-PD won't work.
1. Sets a static IPv6 network with a ULA prefix of `fd95:0c38:25f0::/48`. This is just 40 random bits from `openssl rand -hex 5` and can be whatever. The reasoning for all this is to have a statically known address for the router itself since it will be the IPv6 DNS server (which is advertised via DCHPv6 in stateless mode). If Monkeybrains says the /56 prefix is truly static, the ULA address and routes can be dropped, and the dhcpv6-server name-server line can reference the routeable address of the router as the DNS server.

Fixes: https://github.com/noisebridge/infrastructure/issues/128