### PR TITLE
Add donate.noisebridge.net link

### DIFF
--- a/roles/mediawiki/templates/index.html
+++ b/roles/mediawiki/templates/index.html
@@ -106,6 +106,7 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link">Donate</a>
             <div class="navbar-dropdown">
+              <a class="navbar-item" href="https://donate.noisebridge.net">Credit or Debit</a>
               <a class="navbar-item" href="https://www.patreon.com/noisebridge">Patreon</a>
               <a class="navbar-item" href="Donate_or_Pay_Dues#Alternatives_to_Paypal">Check or Cash</a>
               <a class="navbar-item" href="Bitcoin">Bitcoin</a>


### PR DESCRIPTION
Donate is still the cheapest (3% fees) way to give money to Noisebridge. I know people are working on redoing it but let's make sure it shows up on the menu for now.