### PR TITLE
libssl-dev required for python mysqlclient

### DIFF
--- a/group_vars/m5-noisebridge-net/mysql.yml
+++ b/group_vars/m5-noisebridge-net/mysql.yml
@@ -3,6 +3,7 @@ mysql_packages:
 - percona-server-server
 - percona-server-client
 - libperconaserverclient21-dev
+- libssl-dev
 mysql_bind_address: 127.0.0.1
 mysql_databases:
 - name: noisebridge_donate


### PR DESCRIPTION
Another dep but everything installs with this so we're good now.