### PR TITLE
Adding deploy to mailing lists and aliases to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You can be even more specific, for example, this deploys only to the noisebridge
 
     ansible-playbook site.yml --limit noisebridge-net -t website
 
+and this deploys only to the email aliases mailing lists:
+
+    ansible-playbook site.yml --limit noisebridge-net -t lists-noisebridge-net
+
 ### Remote access to .noise
 
 In order to deploy to machines remotely, you will need to configure a bastion bouncer.


### PR DESCRIPTION
Open to other suggestions:

I broke mediawiki today because I accidentally ran

```ansible-playbook site.yml --limit lists-noisebridge-net```

not realizing that `lists-noisebridge-net` is actually just a tag under `noisebridge-net`, and not its own name. This resulted in all the Noisebridge websites being deployed (rather than just the mailing lists and email aliases), and the mediawiki happened to have a breaking change that was not deployed until i ran this. The command should have been

```ansible-playbook site.yml --limit noisebridge-net -t lists-noisebridge-net```

So I'm adding the correct command to the README. But if you have any ideas on how to make it more intuitive, I'm happy to do that instead. For example, can we get it to throw an error and refuse to deploy if i `--limit` it to a name that doesn't exist?