### PR TITLE
[WIP] initial install of fail2ban, no monitoring confg'd yet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "roles/cloudalchemy.grafana"]
 	path = roles/cloudalchemy.grafana
 	url = https://github.com/cloudalchemy/ansible-grafana.git
+[submodule "roles/ansible-fail2ban"]
+	path = roles/ansible-fail2ban
+	url = git@github.com:nickjj/ansible-fail2ban.git

--- a/site.yml
+++ b/site.yml
@@ -27,6 +27,7 @@
 
 - name: noisebridge-net
   hosts: noisebridge-net
+  gather_facts: yes
   become: yes
   become_method: sudo
   tags: [noisebridge-net]
@@ -43,7 +44,10 @@
   hosts: donate-noisebridge-net
   become: yes
   become_method: sudo
+  gather_facts: yes
   tags: [donate]
+  vars:
+    ansible_pkg_mgr: apt
   roles:
     - donate
     - percona
@@ -101,6 +105,7 @@
   hosts: m4-noisebridge-net
   become: yes
   become_method: sudo
+  gather_facts: yes
   tags: [m4-noisebridge-net]
   roles:
     - { role: antoiner77.caddy, tags: [ 'caddy' ] }
@@ -120,3 +125,11 @@
   tags: [smartpi]
   roles:
     - smartpi
+
+- name: fail2ban
+  hosts: donate-noisebridge-net
+  become: yes
+  become_method: sudo
+  tags: [fail2ban]
+  roles:
+    - ansible-fail2ban

--- a/site.yml
+++ b/site.yml
@@ -27,7 +27,6 @@
 
 - name: noisebridge-net
   hosts: noisebridge-net
-  gather_facts: yes
   become: yes
   become_method: sudo
   tags: [noisebridge-net]
@@ -44,10 +43,7 @@
   hosts: donate-noisebridge-net
   become: yes
   become_method: sudo
-  gather_facts: yes
   tags: [donate]
-  vars:
-    ansible_pkg_mgr: apt
   roles:
     - donate
     - percona
@@ -105,7 +101,6 @@
   hosts: m4-noisebridge-net
   become: yes
   become_method: sudo
-  gather_facts: yes
   tags: [m4-noisebridge-net]
   roles:
     - { role: antoiner77.caddy, tags: [ 'caddy' ] }


### PR DESCRIPTION
@SuperQ @ruthgrace @rizend 

can we add fail2ban (or anything else like it) to m5 please?  donate is getting hammered, and fail2ban would deal with it easily since it's like the same IP address in large chunks of the logs.

This change adds a submodule ansible-fail2ban and installs it but does no config.  I couldn't find canned filters for our setup.

Also, i had to manually add ansible_pkg_mgr to get past caddy install.  I can't figure out why, i updated submodules, etc.  I've seen people say to explicitly gather facts, so I added that.  IT's  WIP, and those can be reverted easily.  I just wanted to have something ready to discuss.

I'm probably going to also have to put a captcha on donate.  that was also in the pipeline.  Auto-banning failed attempts will help a lot though.