### PR TITLE
make mission less rambly

### DIFF
--- a/roles/website/templates/index.html
+++ b/roles/website/templates/index.html
@@ -189,7 +189,7 @@
                   What is Noisebridge?
                 </h1>
                 <p>
-                   Noisebridge an anarchist hackerspace in San Francisco, and one of the oldest hackerspaces in the US. We grew out of conversations between attendees of Chaos Communication Congress 2007 (24c3), and were originally modeled on c-base in Berlin and Metalab in Vienna. We aim to provide a space for people to hack, create, learn, and explore in a safe, welcoming, and accessible environment.
+                   We are an accessible space for people interested in art and the intersection of art with technology to learn, play, create, and share. Our facilities include infrastructure for work with textiles, music, wood, metal, computer programming, electronics, science, philosophy, and robotics.
                 </p>
                 <p>
                 You don't have to be a member or pay anything to participate in Noisebridge, we're free and open. You just have to follow the one rule: <b>Be Excellent to Each Other!</b>

--- a/roles/website/templates/index.html
+++ b/roles/website/templates/index.html
@@ -189,7 +189,7 @@
                   What is Noisebridge?
                 </h1>
                 <p>
-                   We are an accessible space for people interested in art and the intersection of art with technology to learn, play, create, and share. Our facilities include infrastructure for work with textiles, music, wood, metal, computer programming, electronics, science, philosophy, and robotics.
+                  We are an accessible, community-operated, non-profit hackerspace for artists and audiences interested in the intersection of art, technology, and creative expression.  We are a place to learn, play, create, and share. Our facilities seek to provide infrastructure for work utilizing textiles, music, wood, metal, computer programming, electronics, science, robotics, space for performance or display, and collaboration.
                 </p>
                 <p>
                 You don't have to be a member or pay anything to participate in Noisebridge, we're free and open. You just have to follow the one rule: <b>Be Excellent to Each Other!</b>


### PR DESCRIPTION
David and I are working on an arts grant, and when they looked at our website, it was unclear that art happens at Noisebridge, even though a ton of art is done here. Removing stuff about CCC -- people who get deeper into the hacker culture can find that out later, rather than reading it on our front page right away.