### PR TITLE
Add secure headers to sites other than www.noisebridge.net

### DIFF
--- a/group_vars/m4-noisebridge-net/caddy.yml
+++ b/group_vars/m4-noisebridge-net/caddy.yml
@@ -11,6 +11,11 @@ caddy_config: |
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
+    }
     proxy / localhost:5000 {
       transparent
     }
@@ -24,6 +29,11 @@ caddy_config: |
       rotate_keep 520
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
+    }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
     }
     proxy / localhost:3000 {
       transparent

--- a/group_vars/m5-noisebridge-net/caddy.yml
+++ b/group_vars/m5-noisebridge-net/caddy.yml
@@ -11,6 +11,11 @@ caddy_config: |
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
+    }
     index index.html
     root /var/www/donate.noisebridge.net
   }
@@ -23,6 +28,11 @@ caddy_config: |
       rotate_keep 520
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
+    }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
     }
     
     proxy / localhost:{{ pydonate_port }} {

--- a/group_vars/noisebridge-net/caddy.yml
+++ b/group_vars/noisebridge-net/caddy.yml
@@ -94,6 +94,11 @@ caddy_config: |
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
+    }
     root /srv/mailman/lists.noisebridge.net
 
     cgi /admin /var/lib/mailman/cgi-bin/admin
@@ -154,6 +159,11 @@ caddy_config: |
       rotate_keep 520
       rotate_compress
       ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
+    }
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
     }
     index index.php
     fastcgi / unix:/run/php/php7.0-fpm.sock php


### PR DESCRIPTION
I was playing with wireshark earlier today and ended up noticing that some noisebridge domains don't have HSTS headers.  This PR adds the three standard secure headers already in use on `www.noisebridge.net` to `{parts,library,donate,test-donate,lists,safespace}.noisebridge.net`.