### PR TITLE
Add elimisteve to m5.noisebridge.net

### DIFF
--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -29,6 +29,10 @@ users:
     fullname: ''
     email: ...
 
+  elimisteve:
+    fullname: 'Steve Phillips'
+    github_username: elimisteve
+
   gareth:
     fullname: ',,,'
     email: ...

--- a/host_vars/m5.noisebridge.net/users.yml
+++ b/host_vars/m5.noisebridge.net/users.yml
@@ -1,4 +1,5 @@
 ---
 noisebridge_admins:
+- elimisteve
 - ruthgrace
 - superq


### PR DESCRIPTION
* Add elimisteve to user list.
* Add elimisteve as admin to m5.noisebridge.net.

Signed-off-by: Ben Kochie <superq@gmail.com>