### PR TITLE
Add noisebridge.io

### DIFF
--- a/files/coredns/zones/noisebridge.io
+++ b/files/coredns/zones/noisebridge.io
@@ -1,0 +1,25 @@
+; vim: ts=8 et
+;zone for noisebridge.io
+
+$TTL 3600
+
+noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridge.io.  (
+        2020033100 ; Serial
+        3600 ; Refresh
+        300 ; Retry
+        604800 ; Expire
+        300 ) ; Minimum
+
+; name server records
+@               IN      NS      ns1.noisebridge.net.
+@               IN      NS      ns2.noisebridge.net.
+
+; hostnameless access
+@       300     IN      A       216.252.162.220
+@       300     IN      AAAA    2602:ff06:725:5:dc::1337
+
+; SPF
+@       86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
+
+; aliases
+www     300     IN      CNAME   m3.noisebridge.net.

--- a/group_vars/noisebridge_net/caddy.yml
+++ b/group_vars/noisebridge_net/caddy.yml
@@ -14,6 +14,19 @@ caddy_config: |
     redir https://www.noisebridge.net{uri}
   }
 
+  noisebridge.io, www.noisebridge.io {
+    prometheus
+    gzip
+    log "{{ caddy_log_dir }}/noisebridge.io.log" {
+      rotate_size 50
+      rotate_age 7
+      rotate_keep 520
+      rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
+    }
+    redir https://www.noisebridge.net{uri}
+  }
+
   noisebridge.net {
     prometheus
     gzip

--- a/group_vars/primary_dns_server.yml
+++ b/group_vars/primary_dns_server.yml
@@ -13,6 +13,18 @@ coredns_config: |
     prometheus
     errors
   }
+  noisebridge.io {
+    file zones/noisebridge.io {
+      # ns1.noisebridge.net (m3.noisebridge.net)
+      transfer to 216.252.162.220
+      transfer to 2602:ff06:725:5:dc::1337
+      # ns2.noisebridge.net (m4.noisebridge.net)
+      transfer to 204.246.122.84
+      transfer to 2602:ff06:677:4:54::1337
+    }
+    prometheus
+    errors
+  }
   noisebridge.net {
     file zones/noisebridge.net {
       # ns1.noisebridge.net (m3.noisebridge.net)

--- a/group_vars/secondary_dns_server.yml
+++ b/group_vars/secondary_dns_server.yml
@@ -10,6 +10,15 @@ coredns_config: |
     prometheus
     errors
   }
+  noisebridge.io {
+    secondary {
+      # ns1.noisebridge.net (m3.noisebridge.net)
+      transfer from 216.252.162.220
+      transfer from 2602:ff06:725:5:dc::1337
+    }
+    prometheus
+    errors
+  }
   noisebridge.net {
     secondary {
       # ns1.noisebridge.net (m3.noisebridge.net)


### PR DESCRIPTION
* Add noisebridge.io to DNS service.
* Add redirect from noisebride.io to noisebridge.net.

Signed-off-by: Ben Kochie <superq@gmail.com>