### PR TITLE
Add a code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 This repo contains configuration and code to deploy Noisebridge infrastrucutre.
 
+## Code of Conduct
+
+Noisebridge infrastructure members follow the Rack Code of Conduct
+
+### Security
+
+Noisebridge infrastructure members protect the privacy and security of our systems and members.
+
+* Secrets should be checked in using ansible-vault.
+* The vault password should be kept safe.
+* Care needs to be taken when handling Issues and PRs to protect the privacy of members.
+
+### Reliability
+
+Noisebridge infrastructure members keep services up and running.
+
+* Test changes as best as you can before pushing to production.
+* Improve monitoring as you go.
+* Think first, deploy once.
+* Rollback quickly when things fail.
+
+### Reproducibility
+
+Noisebridge infrastructure members ensure that changes are made in a way that is reproducibile.
+
+* All changes to infrastructure should be checked into this repo.
+* Changes should be made with Pull Requests so that they can be reviewed.
+* Think about making sure your changes are reasonably future-proof.
+
 ## Ansible
 
 Much of the code here is the Noisebridge infrastucture [Ansible](https://docs.ansible.com/ansible/latest/) configuration. Ansible is used to automatically deploy configuration to the various nodes (VMs and hardware in the space).
@@ -30,7 +59,7 @@ You can be even more specific, for example, this deploys only to the noisebridge
 
 Some data is encrypted so that secrets (ie people's email addresses) aren't public. To edit files with secrets, first put the ansible vault password in a `.vault-password` file in the root directory of the git repo, then run:
 
-```ansible-vault edit path/to/secrets.yml```
+    ansible-vault edit path/to/secrets.yml
 
 To get the vault password, check https://www.noisebridge.net/wiki/Accounts to see who has it.
 


### PR DESCRIPTION
This is a technical code of conduct for maintinaing Noisebridge
infrastructure.
* Fix up some minor markdown formatting.

Signed-off-by: Ben Kochie <superq@gmail.com>