### PR TITLE
Added a barnyard subdomain

### DIFF
--- a/files/coredns/zones/noisebridge.io
+++ b/files/coredns/zones/noisebridge.io
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridge.io.  (
-        2020122000 ; Serial
+        2022020600 ; Serial
         3600 ; Refresh
         300 ; Retry
         604800 ; Expire
@@ -21,8 +21,12 @@ noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridg
 ; SPF
 @       86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
 
+; subdomains
+barnyard        86400   IN      NS      brony.noisebridge.io
+
 ; aliases
 blog            10800   IN      CNAME   blogs.vip.gandi.net.
+brony           1800    IN      A       199.241.139.224
 cia             1800    IN      A       199.188.195.8
 cycletrailer    1800    IN      CNAME   cycletrailer.noisebridge.net.
 jitsi           1800    IN      A       199.188.195.96

--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2020022200 ; Serial
+                                2022020600 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -187,6 +187,9 @@ mail            IN      MX      10 mxb.mailgun.org.
 ; arion host @patrickod 2016-12-17
 arion           IN      A       107.170.198.46
 arion           IN      AAAA    2604:a880:1:20::197e:b001
+
+; general subdomains
+barnyard        IN      NS      brony.noisebridge.io
 
 ; m4 testing subdomains
 *.m4            IN      CNAME   m4


### PR DESCRIPTION
Added a subdomain: barynyard.noisebridge.io/org/net we
delegate to brony.noisebridge.io which is currently
authortitative for those domains