### PR TITLE
Fix barnyard NS

### DIFF
--- a/files/coredns/zones/noisebridge.io
+++ b/files/coredns/zones/noisebridge.io
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridge.io.  (
-        2022020600 ; Serial
+        2022020601 ; Serial
         3600 ; Refresh
         300 ; Retry
         604800 ; Expire
@@ -22,7 +22,7 @@ noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridg
 @       86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
 
 ; subdomains
-barnyard        86400   IN      NS      brony.noisebridge.io
+barnyard        86400   IN      NS      brony.noisebridge.io.
 
 ; aliases
 blog            10800   IN      CNAME   blogs.vip.gandi.net.

--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2022020600 ; Serial
+                                2022020601 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -189,7 +189,7 @@ arion           IN      A       107.170.198.46
 arion           IN      AAAA    2604:a880:1:20::197e:b001
 
 ; general subdomains
-barnyard        IN      NS      brony.noisebridge.io
+barnyard        IN      NS      brony.noisebridge.io.
 
 ; m4 testing subdomains
 *.m4            IN      CNAME   m4


### PR DESCRIPTION
Make NS fully qualified to avoid lookups becoming
brony.noisebridge.io.noisebridge.net.

Signed-off-by: SuperQ <superq@gmail.com>