### PR TITLE
Update DNS for the new space.

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2022020601 ; Serial
+                                2022031401 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -147,9 +147,11 @@ zine            IN      A       96.126.98.79
 cabal           IN      A       216.252.162.58
 
 ; Services in the space
-cycletrailer    IN      AAAA    2607:f598:b2c0:277::f001
-cycletrailer    IN      A       192.195.83.130
-2169            IN      CNAME   cycletrailer
+biketrailer     IN      AAAA    2607:f598:b2c0:277::f001
+biketrailer     IN      A       192.195.83.130
+cycletrailer    IN      CNAME   biketrailer
+2169            IN      CNAME   biketrailer
+272             IN      CNAME   biketrailer
 earl            IN      AAAA    2607:f598:b2cf:100:f8ea:fa58:5dd2:6ff4
 pegasus         IN      AAAA    2607:f598:b2cf:100:250:c2ff:fe28:3070
 pegasus         IN      A       192.195.83.134


### PR DESCRIPTION
cycletrailer is actually biketrailer. Deprecate cycletrailer and replace with
  biketrailer.
2169.noisebridge.net should be deprecated.
272.noisebridge.net is the new WAN address.

Signed-off-by: jof <jof@thejof.com>