### PR TITLE
Add acl package

### DIFF
--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -5,6 +5,7 @@
   vars:
     packages:
       - ack-grep
+      - acl
       - apt-transport-https
       - bash-completion
       - bind9-host


### PR DESCRIPTION
Install the acl package for Ansible become_user (reference: [0]).

[0]: https://docs.ansible.com/ansible-core/2.12/user_guide/become.html#risks-of-becoming-an-unprivileged-user

Signed-off-by: SuperQ <superq@gmail.com>