### PR TITLE
Fix up lists CNAME

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2022052400 ; Serial
+                                2022052401 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -42,7 +42,10 @@ m3      300     IN      MX      10 m3.noisebridge.net.
 
 ; aliases
 www     300     IN      CNAME   m3.noisebridge.net.
-lists   300     IN      CNAME   m3.noisebridge.net.
+
+; Email list server
+lists   300     IN      A       216.252.162.220 ; m3.noisebridge.net
+lists   300     IN      AAAA    2602:ff06:725:5:dc::1337 ; m3.noisebridge.net
 lists   86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
 lists   300     IN      TXT     "google-site-verification=WZsrRMmL-XJC-kDfPgvxPZRTaTA3HbHz0BnFcve8Qo8"
 


### PR DESCRIPTION
Replace lists CNAME with A/AAAA canoical records to fix lookup problems.

https://datatracker.ietf.org/doc/html/rfc1034#section-3.6.2

> If a CNAME RR is present at a node, no other data should be
> present; this ensures that the data for a canonical name and its
> aliases cannot be different.

Signed-off-by: SuperQ <superq@gmail.com>