### PR TITLE
Add discuss list as an additional to mediation

### DIFF
--- a/group_vars/noisebridge_net/postfix.yml
+++ b/group_vars/noisebridge_net/postfix.yml
@@ -82,3 +82,4 @@ postfix_aliases:
     alias:
     - mediation-request@lists.noisebridge.net
     - mediation-request-mai-aaaagpdjplmjkpwofzaa4pu7dy@noisebridge.slack.com
+    - noisebridge-discuss@lists.noisebridge.net


### PR DESCRIPTION
This is a shotgun attempt at a fix for the situation,

What we have currently (forwarding to slack, does work fine), but Gaardn wants mediation to also go to the discuss mailing list so that the vast number of existing subscribers will also be able to see them, see:

https://noisebridge.slack.com/archives/C02B511QP/p1653683362032399?thread_ts=1653240555.640509&cid=C02B511QP

I am, however skeptical that this will work in practice,  some people have not been able to reliably receive emails from the mailing lists (due to Gmail blocking our mail server) and you must be subscribed to list (which requires receiving an email from us) in order to post to the list...