### PR TITLE
Update mydumper

### DIFF
--- a/roles/mydumper/defaults/main.yml
+++ b/roles/mydumper/defaults/main.yml
@@ -2,7 +2,6 @@
 mydumper_contact: "root"
 mydumper_backup_dir: "/var/backups/mysql"
 mydumper_log_file: "/var/log/mysql_backup.log"
-mydumper_version: 0.9.5
-mydumper_package_rev: 2
-# Make sure to include .prom in the filename.
-mydumper_metrics_textfile: "/var/lib/node_exporter/mydumper.prom"
+mydumper_version: 0.13.1-1
+mydumper_metrics_dir: "/var/lib/node_exporter"
+mydumper_backup_days: 28

--- a/roles/mydumper/files/mysql_backup.sh
+++ b/roles/mydumper/files/mysql_backup.sh
@@ -6,7 +6,7 @@
 # Override them in /etc/default/mysql_backup
 BACKUP_DIR=/var/backups/mysql
 MAXAGE=7 #days
-METRICS_FILE=/opt/node_exporer/textfile/mysql_backup.prom
+METRICS_DIR=/var/lib/node_exporer
 
 set -o pipefail
 
@@ -42,7 +42,7 @@ METRICS
 
 exit_handler() {
   metric_backup_completed="$(date -u '+%s')"
-  print_status_metrics | sponge "${METRICS_FILE}"
+  print_status_metrics | sponge "${METRICS_FILE}/mysql_backup.prom"
 }
 
 trap exit_handler EXIT
@@ -74,6 +74,7 @@ timeout --signal=TERM --kill-after=1h 4h \
     --outputdir "${output_dir}" \
     --regex '^(?!(information_schema|performance_schema|sys)\.)' \
     --less-locking \
+    --pmm-path="${METRICS_DIR}/" \
     --use-savepoints \
     --trx-consistency-only \
     --rows 100000

--- a/roles/mydumper/tasks/main.yml
+++ b/roles/mydumper/tasks/main.yml
@@ -2,11 +2,12 @@
 - name: Install utils
   apt:
     package:
+    - libzstd1
     - moreutils
 
 - name: Install mydumper
   apt:
-    deb: "https://github.com/maxbube/mydumper/releases/download/v{{ mydumper_version }}/mydumper_{{ mydumper_version }}-{{ mydumper_package_rev }}.stretch_amd64.deb" # noqa 204
+    deb: "https://github.com/maxbube/mydumper/releases/download/v{{ mydumper_version }}/mydumper_{{ mydumper_version }}-zstd.{{ ansible_lsb.codename}}_amd64.deb" # noqa 204
 
 - name: Create backup directory
   file:

--- a/roles/mydumper/templates/defaults
+++ b/roles/mydumper/templates/defaults
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 BACKUP_DIR="{{ mydumper_backup_dir }}"
-METRICS_FILE="{{ mydumper_metrics_textfile }}"
+METRICS_DIR="{{ mydumper_metrics_dir }}"
 LOGFILE="{{ mydumper_log_file }}"
-MAXAGE=7 # Days
+MAXAGE="{{ mydumper_backup_days }}" # Days


### PR DESCRIPTION
Updating to the latest version that supports zstd compression, reduces backup size by 40%.
* Update to the latest version.
* Switch to zstd compression version.
* Enable built-in metrics output.
* Increase backup retention to 4 weeks.

Signed-off-by: SuperQ <superq@gmail.com>