### PR TITLE
Add a robots.txt file

### DIFF
--- a/roles/mediawiki/files/robots.txt
+++ b/roles/mediawiki/files/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /wiki/86

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -62,3 +62,11 @@
     owner: "{{ mediawiki.system_user }}"
     group: "{{ mediawiki.system_group }}"
     mode: 0640
+
+- name: Place robots.txt
+  copy:
+    src: robots.txt
+    dest: "/srv/mediawiki/{{ mediawiki.domain }}/robots.txt"
+    mode: 0444
+  tags:
+    - robots_txt


### PR DESCRIPTION
And Disallow the /wiki/86 page; this sensitive page should really only be for human consumption.