### PR TITLE
Add caddy certificate copier

### DIFF
--- a/roles/caddy_certs/defaults/main.yml
+++ b/roles/caddy_certs/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+caddy_certs_src_path: "/home/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{ ansible_fqdn }}"
+caddy_certs_modified_path: "{{ caddy_certs_src_path }}/{{ ansible_fqdn }}.crt"
+caddy_certs_dest_path: "/etc/ssl/{{ ansible_fqdn }}"

--- a/roles/caddy_certs/files/copy_certs.sh
+++ b/roles/caddy_certs/files/copy_certs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Description: Copy certificate files from one dir to another and configure permissions.
+
+
+set -e -u -o pipefail
+
+source_dir="$1"
+dest_dir="$2"
+
+if [[ ! -d "${source_dir}" ]] ; then
+  echo "ERROR: Missing source dir '${source_dir}'"
+  exit 1
+fi
+
+if [[ ! -d "${dest_dir}" ]] ; then
+  echo "ERROR: Missing destinatoin dir '${dest_dir}'"
+  exit 1
+fi
+
+cp -v "${source_dir}"/*.{key,crt} "${dest_dir}/"
+chgrp -v ssl-cert "${dest_dir}"/*.{key,crt}
+chmod -v 0640 "${dest_dir}"/*.{key,crt}

--- a/roles/caddy_certs/handlers/main.yml
+++ b/roles/caddy_certs/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Reload caddy_certs.path
+  become: true
+  ansible.builtin.systemd:
+    name: caddy_certs.path
+    daemon_reload: true
+
+- name: Restart caddy_certs.service
+  become: true
+  ansible.builtin.systemd:
+    name: caddy_certs.service
+    daemon_reload: true
+    state: restarted

--- a/roles/caddy_certs/tasks/main.yml
+++ b/roles/caddy_certs/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Install copy script
+  ansible.builtin.copy:
+    src: copy_certs.sh
+    dest: /usr/local/sbin/copy_certs.sh
+    owner: root
+    group: root
+    mode: 0755
+  notify:
+    - Restart caddy_certs.service
+
+- name: Create cert directory
+  ansible.builtin.file:
+    path: "{{ caddy_certs_dest_path }}"
+    state: directory
+    owner: root
+    group: ssl-cert
+    mode: 0750
+
+- name: Configure watch certs path
+  ansible.builtin.template:
+    src: caddy_certs.path.j2
+    dest: /etc/systemd/system/caddy_certs.path
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Reload caddy_certs.path
+
+- name: Configure copy certs service
+  ansible.builtin.template:
+    src: caddy_certs.service.j2
+    dest: /etc/systemd/system/caddy_certs.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Restart caddy_certs.service
+
+- name: Enable caddy_certs.path
+  ansible.builtin.systemd:
+    name: caddy_certs.path
+    enabled: true
+
+- name: Enable caddy_certs.service
+  ansible.builtin.systemd:
+    name: caddy_certs.service
+    enabled: true

--- a/roles/caddy_certs/templates/caddy_certs.path.j2
+++ b/roles/caddy_certs/templates/caddy_certs.path.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Caddy watch for new certs
+After=network-online.target
+StartLimitInterval=0
+StartLimitIntervalSec=0
+
+[Path]
+PathModified={{ caddy_certs_modified_path }}
+Unit=caddy_certs.service

--- a/roles/caddy_certs/templates/caddy_certs.service.j2
+++ b/roles/caddy_certs/templates/caddy_certs.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Caddy watch for new certs
+After=network-online.target
+StartLimitInterval=0
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/copy_certs.sh {{ caddy_certs_src_path }} {{ caddy_certs_dest_path }}
+TimeoutStartSec=30s
+
+
+[Install]
+WantedBy=multi-user.target

--- a/site.yml
+++ b/site.yml
@@ -40,6 +40,7 @@
     - { role: prometheus.prometheus.prometheus, tags: [ 'prometheus' ] }
     - { role: mydumper, tags: [ 'mydumper' ] }
     - { role: caddy, tags: [ 'caddy' ] }
+    - { role: caddy_certs, tags: [ 'caddy_certs' ] }
 
 - name: donate_noisebridge_net
   hosts: donate_noisebridge_net


### PR DESCRIPTION
Use a systemd Path unit to copy the SSL certs from Caddy to a well-known location based on the node FQDN. This allows the letsencrypt certs to be re-used by other things (monitoring exporters, non-http services, etc).
* Certs are group readable by `ssl-cert`.
* Update the Caddy ansible role.