### PR TITLE
Add CoreDNS monitoring

### DIFF
--- a/group_vars/noisebridge_net/prometheus.yml
+++ b/group_vars/noisebridge_net/prometheus.yml
@@ -45,9 +45,15 @@ prometheus_scrape_configs:
         - "m6.noisebridge.net:443"
         - "m7.noisebridge.net:443"
   - job_name: "coredns"
+    scheme: https
+    metrics_path: /coredns/metrics
+    basic_auth:
+      username: prometheus
+      password: "{{ noisebridge_prometheus_password }}"
     static_configs:
       - targets:
-        - "localhost:9153"
+        - "m3.noisebridge.net:443"
+        - "m7.noisebridge.net:443"
   - job_name: "donate"
     scheme: https
     static_configs:

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -14,6 +14,12 @@
     }
     metrics
   }
+  handle_path /coredns/* {
+    basicauth {
+      prometheus {{ noisebridge_prometheus_password_hash }}
+    }
+    reverse_proxy localhost:9153
+  }
   respond "Noisebridge Infrastructure - {{ ansible_fqdn }}"
 }
 

--- a/templates/caddy/m7/Caddyfile.j2
+++ b/templates/caddy/m7/Caddyfile.j2
@@ -13,5 +13,11 @@
     }
     metrics
   }
+  handle_path /coredns/* {
+    basicauth {
+      prometheus {{ noisebridge_prometheus_password_hash }}
+    }
+    reverse_proxy localhost:9153
+  }
   respond "Noisebridge Infrastructure - {{ ansible_fqdn }}"
 }

--- a/templates/coredns/Corefile.primary.j2
+++ b/templates/coredns/Corefile.primary.j2
@@ -2,7 +2,7 @@
 {% for zone in noisebridge_dns_primary_zones %}
 # Zone: {{ zone.name }}
 {{ zone.name }} {
-  prometheus 0.0.0.0:9153
+  prometheus localhost:9153
   errors
   file zones/{{ zone.file }}
 {% if zone.dnssec_key_file is defined %}

--- a/templates/coredns/Corefile.secondary.j2
+++ b/templates/coredns/Corefile.secondary.j2
@@ -2,7 +2,7 @@
 {% for zone in noisebridge_dns_seconary_zones %}
 # Zone: {{ zone.name }}
 {{ zone.name }} {
-  prometheus 0.0.0.0:9153
+  prometheus localhost:9153
   errors
   secondary {
     transfer from {{ zone.transfer_from | join(' ') }}


### PR DESCRIPTION
Move CoreDNS to listen on localhost for metrics and handle access via a Caddy proxy with basic auth.
* Add CoreDNS servers to Prometheus monitoring.