### PR TITLE
Fixup wiki root

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -90,7 +90,7 @@ www.noisebridge.net {
       root /srv/mediawiki/noisebridge.net/images
     }
   }
-  root * /srv/mediawiki/noisebridge.net
+  root * /srv/mediawiki/noisebridge.net-upgrade-2023
   php_fastcgi unix//run/php/php8.2-fpm.sock
   file_server {
     hide *.php


### PR DESCRIPTION
Use the temporary wiki root dir while upgrades are in progress.