### PR TITLE
Ignore dependabot in /colllections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+---
+version: 2
+updates:
+  - directory: "/collections"
+    package-ecosystem: "pip"
+    ignore: "*"


### PR DESCRIPTION
Avoid dependabot from opening PRs against the vendored `/collections`.