### PR TITLE
Configure Prometheus retention size

### DIFF
--- a/group_vars/noisebridge_net/prometheus.yml
+++ b/group_vars/noisebridge_net/prometheus.yml
@@ -1,6 +1,7 @@
 ---
 prometheus_web_listen_address: "127.0.0.1:9090"
 prometheus_storage_retention: "90d"
+prometheus_storage_retention_size: "5GB"
 prometheus_config_flags_extra:
   query.max-samples: 10000000
 


### PR DESCRIPTION
Limit Prometheus to 5GB of storage space.