### PR TITLE
Ingore /roles for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
   - directory: "/collections"
     package-ecosystem: "pip"
     ignore: "*"
+  - directory: "/roles/hifis.unattended_upgrades"
+    package-ecosystem: "pip"
+    ignore: "*"


### PR DESCRIPTION
Also ignore `/roles/hifis.unattended_upgrades` for dependabot updates as this is a vendored role.