### PR TITLE
Ansible-ize wiki extension downloads

### DIFF
--- a/roles/mediawiki/tasks/extensions.yml
+++ b/roles/mediawiki/tasks/extensions.yml
@@ -1,0 +1,13 @@
+---
+# {{ mediawiki.version_tag }}  # REL1_39
+- name: install mwGoogleSheets extension
+  git:
+    repo: 'https://github.com/marcidy/mwGoogleSheet.git'
+    dest: "/srv/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
+    version: REL1_27
+
+- name: https://www.mediawiki.org/wiki/Extension:CategoryTree
+  git:
+    #repo:  # wikimedia gerrit, or github  # 'https://github.com/marcidy/mwGoogleSheet.git'
+    dest: "/srv/mediawiki/{{ mediawiki.domain }}/extensions/CategoryTree"
+    version: REL1_39

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -44,6 +44,7 @@
     repo: 'https://github.com/marcidy/mwGoogleSheet.git'
     dest: "/srv/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
     version: REL1_27
+#- include: extensions.yml
 
 - name: install LocalSettings
   template:


### PR DESCRIPTION

These will come from
* github
* wikimedia's gerrit
* tar ball downloads

To enable the wiki, with extensions, to be deployed in one step.
