### PR TITLE
wiki extensions -- link shortener & graph

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -324,5 +324,7 @@ wfLoadExtension( 'CategoryTree' );
 # https://www.mediawiki.org/wiki/Extension:ImageMap
 wfLoadExtension( 'ImageMap' );
 
+# https://www.noisebridge.net/wiki/Nb.wtf # https://github.com/audiodude/nb.wtf
+wfLoadExtension( 'NBWTF' );
 
 #$wgReadOnly = '[issue] [timeframe] -User:[admin]';

--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -327,4 +327,9 @@ wfLoadExtension( 'ImageMap' );
 # https://www.noisebridge.net/wiki/Nb.wtf # https://github.com/audiodude/nb.wtf
 wfLoadExtension( 'NBWTF' );
 
+# https://www.mediawiki.org/wiki/Extension:JsonConfig
+wfLoadExtension( 'JsonConfig' );
+# https://www.mediawiki.org/wiki/Extension:Graph
+wfLoadExtension( 'Graph' );
+
 #$wgReadOnly = '[issue] [timeframe] -User:[admin]';


### PR DESCRIPTION
This PR adds an extension to update shortlinks on save.
https://www.noisebridge.net/wiki/Nb.wtf, built from [gh:audiodude/nb.wtf](https://github.com/audiodude/nb.wtf).

It also add Vega graphing from [mw:Extension:Graph](https://www.mediawiki.org/wiki/Extension:Graph), and its dependency [mw:Extension:JsonConfig](https://www.mediawiki.org/wiki/Extension:JsonConfig).
