### PR TITLE
m3: Update Caddyfile.j2, 400 for non-expected host headers

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -181,3 +181,11 @@ prometheus.noisebridge.net {
     reverse_proxy localhost:9090
   }
 }
+
+https:// {
+  tls internal
+  respond 400 {
+    body "Host header not valid"
+    close
+  }
+}


### PR DESCRIPTION
Dealing with requests like these, that scan for secrets and don't even present a knowledgable Host header, just the IP.

Response includes a clear reason, so it won't be mysterious to users.

```
Sep 27 15:27:21 m3.noisebridge.net caddy[2614044]: {"level":"info","ts":1759012041.31485,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"78.153.140.2
03","remote_port":"50716","client_ip":"78.153.140.203","proto":"HTTP/1.1","method":"GET","host":"216.252.162.220","uri":"/core/.env","headers":{"Accept":["*/*"],"User-Agent":["
Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 Iceweasel/38.2.1"]}},"bytes_read":0,"user_id":"","duration":0.000039692,"size":0,"status":308,"resp_headers
":{"Server":["Caddy"],"Connection":["close"],"Location":["https://216.252.162.220/core/.env"],"Content-Type":[]}}
```