### PR TITLE
m3/caddy: bsky did

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -61,6 +61,9 @@ noisebridge.net {
     }
 {{ noisebridge_caddy_log_filter | indent(width=4) }}
   }
+  handle /.well-known/atproto-did {
+    respond "did:plc:4fn5ffs6txnxxozezxio3v7o" 200
+  }
   redir https://www.noisebridge.net{uri}
 }
 


### PR DESCRIPTION
Noisebridge has social media presence on many services. On BlueSky, in the [atproto](https://atproto.com)-verse, we can use `noisebridge.net` domain as a handle, we need merely setup a DNS record or HTTP-served response, of a [did](https://en-wp.org/wiki/Decentralized_identifier).

--- 

We may prefer to use DNS.

https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial
https://docs.bsky.app/docs/advanced-guides/resolving-identities

https://bsky.app/profile/noisebridge.net

At `https://noisebridge.net/.well-known/atproto-did`
```
did:plc:4fn5ffs6txnxxozezxio3v7o
```
or, in dns
```bind
_atproto IN TXT did=did:plc:4fn5ffs6txnxxozezxio3v7o
```