### PR TITLE
Add daniel to user files

### DIFF
--- a/group_vars/all/default.yml
+++ b/group_vars/all/default.yml
@@ -5,3 +5,4 @@ noisebridge_admins:
 - bfb
 - jof
 - mcint
+- daniel

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -74,6 +74,11 @@ users:
     email: nb@mcint.io
     github_username: mcint
 
+  daniel:
+    fullname: Daniel Angell
+    email: me@danangell.com
+    github_username: danthedaniel
+
   miloh:
     fullname: 'Ronald Miloh Alexander'
     email: ...

--- a/host_vars/m3.noisebridge.net/users.yml
+++ b/host_vars/m3.noisebridge.net/users.yml
@@ -2,4 +2,5 @@
 noisebridge_users:
 - yar
 - mcint
+- daniel
 - elan

--- a/host_vars/m4.noisebridge.net/users.yml
+++ b/host_vars/m4.noisebridge.net/users.yml
@@ -7,4 +7,5 @@ noisebridge_admins:
 - bfb
 - jof
 - mcint
+- daniel
 - elan

--- a/host_vars/m5.noisebridge.net/users.yml
+++ b/host_vars/m5.noisebridge.net/users.yml
@@ -6,4 +6,5 @@ noisebridge_admins:
 - bfb
 - jof
 - mcint
+- daniel
 - elan

--- a/host_vars/m6.noisebridge.net/users.yml
+++ b/host_vars/m6.noisebridge.net/users.yml
@@ -7,4 +7,5 @@ noisebridge_admins:
 - bfb
 - jof
 - mcint
+- daniel
 - elan


### PR DESCRIPTION
Requesting access to deploy https://github.com/noisebridge/donate-portal to our own infrastructure. I also plan to deploy [bugsink](https://github.com/bugsink/bugsink) or something similar to handle errors. Currently the donation portal is hosted on render.com.

Current plan is to run both of these as docker containers.