### PR TITLE
Enable caddy rate-limit feature

### DIFF
--- a/group_vars/m5_noisebridge_net/caddy.yml
+++ b/group_vars/m5_noisebridge_net/caddy.yml
@@ -1,2 +1,4 @@
 ---
+caddy_features:
+- 'github.com/mholt/caddy-ratelimit@v0.1.0'
 caddy_config: "{{ lookup('template', 'templates/caddy/m5/Caddyfile.j2') }}"

--- a/group_vars/m6_noisebridge_net/caddy.yml
+++ b/group_vars/m6_noisebridge_net/caddy.yml
@@ -1,2 +1,4 @@
 ---
+caddy_packages:
+- 'github.com/mholt/caddy-ratelimit@v0.1.0'
 caddy_config: "{{ lookup('template', 'templates/caddy/m6/Caddyfile.j2') }}"

--- a/group_vars/m7_noisebridge_net/caddy.yml
+++ b/group_vars/m7_noisebridge_net/caddy.yml
@@ -1,4 +1,5 @@
 ---
 caddy_packages:
 - 'github.com/greenpau/caddy-security@v1.1.20'
+- 'github.com/mholt/caddy-ratelimit@v0.1.0'
 caddy_config: "{{ lookup('template', 'templates/caddy/m7/Caddyfile.j2') }}"

--- a/group_vars/noisebridge_net/caddy.yml
+++ b/group_vars/noisebridge_net/caddy.yml
@@ -2,6 +2,7 @@
 caddy_packages:
 - 'github.com/aksdb/caddy-cgi/v2@v2.2.1'
 - 'github.com/greenpau/caddy-security@v1.1.20'
+- 'github.com/mholt/caddy-ratelimit@v0.1.0'
 caddy_config: "{{ lookup('template', 'templates/caddy/m3/Caddyfile.j2') }}"
 
 noisebridge_mailman_cgi_scripts:


### PR DESCRIPTION
Enable `github.com/mholt/caddy-ratelimit` on all Caddy deployments.

Fixes: https://github.com/noisebridge/infrastructure/issues/423