### PR TITLE
Mitigate SVG XSS risk: disable native rendering, add CSP headers

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -91,6 +91,9 @@ www.noisebridge.net {
 
   route /images* {
     uri strip_prefix /images
+    @svg path *.svg *.SVG
+    header @svg Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'"
+    header @svg Content-Disposition "attachment"
     file_server {
       root /srv/mediawiki/noisebridge.net/images
     }


### PR DESCRIPTION
 SVG files can contain embedded JavaScript that executes in the browser.
 This adds Content-Security-Policy and Content-Disposition headers to SVG
 files served from /images to block script execution and prevent inline
 rendering. Wiki page thumbnails are unaffected (they're rasterized PNGs).

 Deploy after merge:
 `ansible-playbook site.yml --limit noisebridge_net -t caddy`