### PR TITLE
Bump noisebridge.net serial

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026011201 ; Serial
+                                2026020700 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire


### PR DESCRIPTION
Update the `noisebridge.net` zone serial number to integrate #425.