### PR TITLE
Enable file caching for anonymous users via mediawiki File cache

### DIFF
--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -22,6 +22,14 @@
     url: "https://releases.wikimedia.org/mediawiki/{{ mediawiki_version | regex_search('\\d+.\\d+') }}/mediawiki-{{ mediawiki_version }}.tar.gz"
     checksum: "sha256:{{ mediawiki_version_checksum }}"
 
+- name: make wiki cache directory
+  file:
+    dest: "/var/cache/mediawiki"
+    state: directory
+    owner: "www-data"
+    group: "www-data"
+    mode: 0755
+
 - name: make wiki directory
   file:
     dest: "/srv/mediawiki/{{ mediawiki.domain }}"

--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -149,8 +149,10 @@ wfLoadExtension( 'mwGoogleSheet' );
 # Add more configuration options below.
 
 $wgUseGzip = true;
-$wgUseFileCache = false;
+$wgUseFileCache = true;
 $wgFileCacheDirectory = '/var/cache/mediawiki/';
+$wgShowIPinHeader = false;
+$wgCdnMaxAge = 7200;
 
 wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
 #wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/QuestyCaptcha', 'QuestyCaptchaEditor' ]);


### PR DESCRIPTION
This was @danthedaniel 's idea originally so I looked up how to do it and this is what I found. I just wanted to open the PR at the least.

This implements file caching to serve static html to anonymous users and the cache be marked fresh for 2 hours.


https://www.mediawiki.org/wiki/Manual:File_cache is what this is based on