### PR TITLE
Enable file caching for anonymous users via caddy souin

### DIFF
--- a/group_vars/noisebridge_net/caddy.yml
+++ b/group_vars/noisebridge_net/caddy.yml
@@ -2,6 +2,8 @@
 caddy_packages:
 - 'github.com/aksdb/caddy-cgi/v2@v2.2.1'
 - 'github.com/greenpau/caddy-security@v1.1.20'
+- 'github.com/darkweak/souin/plugins/caddy'
+- 'github.com/darkweak/souin/plugins/radix-redis'
 caddy_config: "{{ lookup('template', 'templates/caddy/m3/Caddyfile.j2') }}"
 
 noisebridge_mailman_cgi_scripts:

--- a/site.yml
+++ b/site.yml
@@ -41,6 +41,7 @@
     - { role: mydumper, tags: [ 'mydumper' ] }
     - { role: caddy_ansible.caddy_ansible, tags: [ 'caddy' ] }
     - { role: caddy_certs, tags: [ 'caddy_certs' ] }
+    - { role: geerlingguy.redis, tags: [ 'redis' ] }
 
 - name: donate_noisebridge_net
   hosts: donate_noisebridge_net

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -4,6 +4,7 @@
   order cgi last
   order authenticate before respond
   order authorize before basic_auth
+  order cache before rewrite
   security {
     authorization policy noisebridge-github {
       set auth url https://auth.noisebridge.net/auth
@@ -11,6 +12,13 @@
       crypto key token name access_token
       allow roles members rack
     }
+  }
+  cache {
+    redis {
+      url localhost:6379
+    }
+    ttl 7200s
+    stale 3600s
   }
   servers {
       metrics
@@ -84,10 +92,13 @@ www.noisebridge.net {
   }
 {{ noisebridge_caddy_secure_header | indent(width=2) }}
 
-  @claudebot {
-    header User-Agent *ClaudeBot*
+  @anon {
+    not header Cookie *wiki_wiki_UserID*
+    not header Cookie *wiki_wiki_Token*
+    not header Cookie *wiki_wiki__session*
+    not header Cookie *wiki_wiki_mwuser-sessionId*
   }
-  respond @claudebot 403
+  header @anon Cache-Control "public, max-age=7200"
 
   route /images* {
     uri strip_prefix /images


### PR DESCRIPTION
@danthedaniel this uses redis and souin for caddy-level caching. it uses redis and in-memory cache. also 2 hour timeout. This is all using 
https://docs.souin.io/docs/quickstart/