### PR TITLE
Grant nthmost SSH access to m3

### DIFF
--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -86,6 +86,7 @@ users:
   nthmost:
     fullname: 'Naomi Most'
     email: ...
+    github_username: nthmost
 
   patrickod:
     fullname: Patrick O'Doherty

--- a/host_vars/m3.noisebridge.net/users.yml
+++ b/host_vars/m3.noisebridge.net/users.yml
@@ -4,3 +4,4 @@ noisebridge_users:
 - mcint
 - elan
 - jetpham
+- nthmost


### PR DESCRIPTION
## Summary

- Adds `github_username: nthmost` to nthmost's entry in `group_vars/all/users.yml` (was missing, would have caused silent key fetch failure)
- Adds `nthmost` to `noisebridge_users` on m3.noisebridge.net

## Deploy

After merge, run:
```
ansible-playbook site.yml --limit m3.noisebridge.net -t access
```