### PR TITLE
Add wiki_dumps role: nightly public + private MediaWiki exports

### DIFF
--- a/group_vars/noisebridge_net/wiki_dumps.yml
+++ b/group_vars/noisebridge_net/wiki_dumps.yml
@@ -1,0 +1,10 @@
+---
+wiki_dumps_mediawiki_path: /srv/mediawiki/noisebridge.net-1.39.13
+wiki_dumps_localsettings: /srv/mediawiki/LocalSettings.php
+wiki_dumps_user: www-data
+wiki_dumps_private_dir: /var/backups/wiki
+wiki_dumps_public_dir: /var/www/dumps.noisebridge.net
+wiki_dumps_private_keep_days: 14
+wiki_dumps_public_keep_days: 7
+wiki_dumps_cron_hour: 2
+wiki_dumps_cron_minute: 0

--- a/roles/wiki_dumps/defaults/main.yml
+++ b/roles/wiki_dumps/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+wiki_dumps_mediawiki_path: /srv/mediawiki/noisebridge.net-1.39.13
+wiki_dumps_localsettings: /srv/mediawiki/LocalSettings.php
+wiki_dumps_user: www-data
+
+# Private (full) dump — all revisions, deleted content, not public
+wiki_dumps_private_dir: /var/backups/wiki
+wiki_dumps_private_keep_days: 14
+
+# Public dump — current revisions of public pages only, served to bots
+wiki_dumps_public_dir: /var/www/dumps.noisebridge.net
+wiki_dumps_public_keep_days: 7
+
+# Cron schedule (default: 2AM daily)
+wiki_dumps_cron_hour: 2
+wiki_dumps_cron_minute: 0

--- a/roles/wiki_dumps/files/wiki_dump.sh
+++ b/roles/wiki_dumps/files/wiki_dump.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# MediaWiki dump script
+# Generates two dumps:
+#   - private (full, all revisions) for internal backup
+#   - public (current revisions, public pages only) for bot consumption
+
+set -euo pipefail
+
+MEDIAWIKI_PATH="${MEDIAWIKI_PATH:-/srv/mediawiki/noisebridge.net-1.39.13}"
+LOCALSETTINGS="${LOCALSETTINGS:-/srv/mediawiki/LocalSettings.php}"
+PRIVATE_DIR="${PRIVATE_DIR:-/var/backups/wiki}"
+PUBLIC_DIR="${PUBLIC_DIR:-/var/www/dumps.noisebridge.net}"
+PRIVATE_KEEP_DAYS="${PRIVATE_KEEP_DAYS:-14}"
+PUBLIC_KEEP_DAYS="${PUBLIC_KEEP_DAYS:-7}"
+
+PHP="${PHP:-php}"
+TS=$(date -u '+%Y%m%d')
+
+run_dump() {
+  local label="$1"
+  local outfile="$2"
+  shift 2
+  local args=("$@")
+
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Starting ${label} dump -> ${outfile}"
+  "${PHP}" "${MEDIAWIKI_PATH}/maintenance/dumpBackup.php" \
+    --conf "${LOCALSETTINGS}" \
+    --output "gzip:${outfile}.tmp" \
+    "${args[@]}"
+  mv "${outfile}.tmp" "${outfile}"
+  ln -sf "${outfile}" "$(dirname "${outfile}")/latest.xml.gz"
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Completed ${label} dump ($(du -sh "${outfile}" | cut -f1))"
+}
+
+# Private: full dump including all revisions and deleted content
+run_dump "private" "${PRIVATE_DIR}/noisebridge-${TS}-full.xml.gz" \
+  --full
+
+# Public: current revision of each page, public namespaces only
+run_dump "public" "${PUBLIC_DIR}/noisebridge-${TS}-public.xml.gz" \
+  --current --public
+
+# Prune old dumps
+find "${PRIVATE_DIR}" -name 'noisebridge-*-full.xml.gz' -mtime "+${PRIVATE_KEEP_DAYS}" -delete
+find "${PUBLIC_DIR}"  -name 'noisebridge-*-public.xml.gz' -mtime "+${PUBLIC_KEEP_DAYS}" -delete
+
+echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Done."

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Create private dump directory
+  file:
+    path: "{{ wiki_dumps_private_dir }}"
+    state: directory
+    owner: "{{ wiki_dumps_user }}"
+    group: "{{ wiki_dumps_user }}"
+    mode: 0750
+
+- name: Create public dump directory
+  file:
+    path: "{{ wiki_dumps_public_dir }}"
+    state: directory
+    owner: "{{ wiki_dumps_user }}"
+    group: "{{ wiki_dumps_user }}"
+    mode: 0755
+
+- name: Deploy dump script
+  copy:
+    src: wiki_dump.sh
+    dest: /usr/local/sbin/wiki_dump
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Install cron job
+  cron:
+    name: MediaWiki Dump
+    cron_file: wiki_dump
+    user: "{{ wiki_dumps_user }}"
+    hour: "{{ wiki_dumps_cron_hour }}"
+    minute: "{{ wiki_dumps_cron_minute }}"
+    job: >-
+      MEDIAWIKI_PATH={{ wiki_dumps_mediawiki_path }}
+      LOCALSETTINGS={{ wiki_dumps_localsettings }}
+      PRIVATE_DIR={{ wiki_dumps_private_dir }}
+      PUBLIC_DIR={{ wiki_dumps_public_dir }}
+      PRIVATE_KEEP_DAYS={{ wiki_dumps_private_keep_days }}
+      PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
+      /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1

--- a/site.yml
+++ b/site.yml
@@ -39,6 +39,7 @@
     - { role: prometheus.prometheus.blackbox_exporter, tags: [ 'blackbox' ] }
     - { role: prometheus.prometheus.prometheus, tags: [ 'prometheus' ] }
     - { role: mydumper, tags: [ 'mydumper' ] }
+    - { role: wiki_dumps, tags: [ 'wiki_dumps' ] }
     - { role: caddy_ansible.caddy_ansible, tags: [ 'caddy' ] }
     - { role: caddy_certs, tags: [ 'caddy_certs' ] }
 

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -177,6 +177,18 @@ safespace.noisebridge.net {
   php_fastcgi unix//run/php/php8.2-fpm.sock
 }
 
+# Wiki dumps (public, for bot consumption)
+dumps.noisebridge.net {
+  log {
+    output file "{{ caddy_log_dir }}/dumps.noisebridge.net.log" {
+{{ noisebridge_caddy_log_roll | indent(width=6) }}
+    }
+{{ noisebridge_caddy_log_filter | indent(width=4) }}
+  }
+  root * {{ wiki_dumps_public_dir }}
+  file_server browse
+}
+
 # Monitoring
 prometheus.noisebridge.net {
   route {


### PR DESCRIPTION
## Summary

Adds a `wiki_dumps` role that runs two nightly `dumpBackup.php` jobs on m3:

- **Private dump** (`--full`): all revisions including deleted content → `/var/backups/wiki/`, kept 14 days, not public
- **Public dump** (`--current --public`): current revision of public pages only → `/var/www/dumps.noisebridge.net/`, kept 7 days

The public dump is served at `dumps.noisebridge.net` via a new Caddy block with directory browsing, giving scrapers/bots a structured download target instead of hammering the live wiki.

Rationale: [The Book of noísbriḋ](https://nthmost.com/w/vikings) — offer the data freely so extraction becomes a download, not a raid.

## Changes

- `roles/wiki_dumps/` — new role (defaults, tasks, shell script)
- `group_vars/noisebridge_net/wiki_dumps.yml` — m3-specific var overrides
- `templates/caddy/m3/Caddyfile.j2` — adds `dumps.noisebridge.net` file server block
- `site.yml` — wires role into `noisebridge_net` play

## Deploy

After merge:
\`\`\`
ansible-playbook site.yml --limit m3.noisebridge.net -t wiki_dumps,caddy
\`\`\`

Note: `dumps.noisebridge.net` will need a DNS A record pointing to m3 before Caddy can get a cert.