### PR TITLE
Remove contended ClaudeBot 403 block

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -84,11 +84,6 @@ www.noisebridge.net {
   }
 {{ noisebridge_caddy_secure_header | indent(width=2) }}
 
-  @claudebot {
-    header User-Agent *ClaudeBot*
-  }
-  respond @claudebot 403
-
   route /images* {
     uri strip_prefix /images
     @svg path *.svg *.SVG


### PR DESCRIPTION
Removes the ClaudeBot user-agent block that was added ~~without consensus~~. Nobody wants this restriction.

See also comments on
https://github.com/noisebridge/infrastructure/pull/432