### PR TITLE
Grant nthmost sudo on m3

### DIFF
--- a/host_vars/m3.noisebridge.net/users.yml
+++ b/host_vars/m3.noisebridge.net/users.yml
@@ -1,7 +1,8 @@
 ---
+noisebridge_admins:
+- nthmost
 noisebridge_users:
 - yar
 - mcint
 - elan
 - jetpham
-- nthmost


### PR DESCRIPTION
Moves nthmost from `noisebridge_users` to `noisebridge_admins` on m3.

## Deploy

```
ansible-playbook site.yml --limit m3.noisebridge.net -t access
```