### PR TITLE
feat(DNS): add locker.noisebridge.net DNS record

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026020900 ; Serial
+                                2026032800 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -182,6 +182,7 @@ _dmarc.donate             IN  TXT  "v=DMARC1; p=none;"
 stuff           IN      CNAME   m6
 parts           IN      CNAME   m6
 library         IN      CNAME   m6
+locker          IN      A       137.184.11.99
 
 ; Services hosted on m7
 auth            IN      CNAME   m7


### PR DESCRIPTION
[Derek asked me to add a DNS record for his project ](https://noisebridge.zulipchat.com/#narrow/channel/558694-rack/topic/.E2.9C.94.20locker.2Enoise.20.7C.20locker.2Enoisebridge.2Eorg.20.3F/with/582364226) so that he can start testing his locker service. This PR adds that record
# Summary
- Add locker.noisebridge.net as an A record pointing to 137.184.11.99 for Derek’s locker service testing
- Bump the noisebridge.net zone serial so secondary DNS servers pick up the change