### PR TITLE
Improve caddy_certs role

### DIFF
--- a/roles/caddy_certs/handlers/main.yml
+++ b/roles/caddy_certs/handlers/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Reload caddy_certs.path
+- name: Restart caddy_certs.path
   become: true
   ansible.builtin.systemd:
     name: caddy_certs.path
     daemon_reload: true
+    state: restarted
 
 - name: Restart caddy_certs.service
   become: true

--- a/roles/caddy_certs/tasks/main.yml
+++ b/roles/caddy_certs/tasks/main.yml
@@ -7,7 +7,7 @@
     group: root
     mode: 0755
   notify:
-    - Restart caddy_certs.service
+    - Restart caddy_certs.path
 
 - name: Create cert directory
   ansible.builtin.file:
@@ -25,7 +25,7 @@
     group: root
     mode: 0644
   notify:
-    - Reload caddy_certs.path
+    - Restart caddy_certs.path
 
 - name: Configure copy certs service
   ansible.builtin.template:
@@ -41,8 +41,10 @@
   ansible.builtin.systemd:
     name: caddy_certs.path
     enabled: true
+    state: started
 
 - name: Enable caddy_certs.service
   ansible.builtin.systemd:
     name: caddy_certs.service
     enabled: true
+    state: started


### PR DESCRIPTION
Improve the reliability of the `caddy_certs` role. Currently they don't activeate correctly and also don't trigger on boot.
* Make sure we restart the `caddy_certs.path` unit on changes.
* Make sure both the path and servie units are started.