### PR TITLE
robots.txt: Add ATL/Current page

### DIFF
--- a/roles/mediawiki/files/robots.txt
+++ b/roles/mediawiki/files/robots.txt
@@ -6,6 +6,13 @@ Noindex: /wiki/86
 Noindex: /86
 Noindex: /index.php?page=86
 
+Disallow: /wiki/AskToLeave/Current
+Disallow: /AskToLeave/Current
+Disallow: /index.php?page=AskToLeave/Current
+Noindex: /wiki/AskToLeave/Current
+Noindex: /AskToLeave/Current
+Noindex: /index.php?page=AskToLeave/Current
+
 User-agent: ClaudeBot
 Disallow: /
 


### PR DESCRIPTION
Continue the tradition established for the [86](https://www.noisebridge.net/wiki/86) page, to not make public indexed record one more thing at stake, a reason to drag out or escalate conflicts.

https://www.noisebridge.net/wiki/AstToLeave/Current