### PR TITLE
Cleanup podman submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "roles/nickjj.docker"]
 	path = roles/nickjj.docker
 	url = https://github.com/nickjj/ansible-docker
-[submodule "roles/podman"]
-	path = roles/podman
-	url = https://github.com/alvistack/ansible-role-podman.git
 [submodule "roles/cloudalchemy.coredns"]
 	path = roles/cloudalchemy.coredns
 	url = https://github.com/cloudalchemy/ansible-coredns.git

--- a/site.yml
+++ b/site.yml
@@ -110,7 +110,6 @@
   become_method: sudo
   tags: [m6_noisebridge_net]
   roles:
-    - { role: podman, tags: ['podman'] }
     - { role: caddy-ansible.caddy-ansible, tags: [ 'caddy' ] }
     - { role: caddy_certs, tags: [ 'caddy_certs' ] }
     - { role: library-org, tags: [ 'library-org' ] }


### PR DESCRIPTION
We never ended up deploying anything on m6 with podman. We also don't need this role anymore since the Debian package of podman is up-to-date enough today.