### PR TITLE
Deploy caching DNS to m5

### DIFF
--- a/group_vars/all/coredns.yml
+++ b/group_vars/all/coredns.yml
@@ -1,0 +1,4 @@
+---
+coredns_config_file: coredns/Corefile.cache.j2
+coredns_zone_files_paths: []
+coredns_key_files_paths: []

--- a/site.yml
+++ b/site.yml
@@ -48,6 +48,7 @@
   become_method: sudo
   tags: [m5]
   roles:
+    - { role: cloudalchemy.coredns, tags: [ 'coredns' ] }
     - { role: prometheus.prometheus.blackbox_exporter, tags: [ 'blackbox' ] }
     - { role: prometheus.prometheus.prometheus, tags: [ 'prometheus' ] }
     - { role: grafana.grafana.grafana, tags: [ 'grafana' ] }

--- a/templates/coredns/Corefile.cache.j2
+++ b/templates/coredns/Corefile.cache.j2
@@ -1,0 +1,15 @@
+{{ ansible_managed | comment }}
+. {
+  bind 127.0.0.1 ::1
+  prometheus localhost:9153
+  errors
+  loop
+  # Forward to quad9.net.
+  forward . tls://2620:fe::fe tls://2620:fe::9 tls://9.9.9.9 tls://149.112.112.112 {
+    tls_servername dns.quad9.net
+    health_check 5s
+  }
+  cache {
+    prefetch 10 60s 10%
+  }
+}


### PR DESCRIPTION
Add a configuration to deploy CoreDNS as a caching forwarding proxy to m5. This reduces jitter/issues in blackbox_exporter probes with regular DNS lookups.