### PR TITLE
Add test-safespace.noisebridge.net

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026032800 ; Serial
+                                2026041000 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -171,6 +171,7 @@ safespace       IN      CNAME   m3
 donate          IN      CNAME   donate-noisebridge-net.onrender.com.
 grafana         IN      CNAME   m5
 prometheus      IN      CNAME   m5
+test-safespace  IN      CNAME   m5
 
 ; donate.noisebridge.net email records (resend.com)
 resend._domainkey.donate  IN  TXT  "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCoQWXGT4XLCErI5+ILqqMcSybWz1DxAqGyw9cxuaPN39YIyD6+SsvoP0p83iX3appGI4EXAVXe2YNPmNaa9UBnG7eio0tUe61L/J/82XEV/XbYTZpCGE5laIbQWZh77BBD9Ie6RpmYW2p1frnSUuz6BmnsT63fCToPfVU8K3jC/wIDAQAB"

--- a/templates/caddy/m5/Caddyfile.j2
+++ b/templates/caddy/m5/Caddyfile.j2
@@ -50,6 +50,18 @@ donate.noisebridge.net {
   respond "This donate endpoint is currently offline" 503
 }
 
+# Safespace site
+test-safespace.noisebridge.net {
+  log {
+    output file "{{ caddy_log_dir }}/test-safespace.noisebridge.net.log" {
+      {{ noisebridge_caddy_log_roll | indent(width=6) }}
+    }
+    {{ noisebridge_caddy_log_filter | indent(width=4) }}
+  }
+  {{ noisebridge_caddy_secure_header | indent(width=2) }}
+  reverse_proxy localhost:5000
+}
+
 # Monitoring
 grafana.noisebridge.net {
   route {


### PR DESCRIPTION
Setup test-safespace.noisebridge.net on m5 to test new container deployment of safespace site.