### PR TITLE
Reduce cAdvisor resource use

### DIFF
--- a/collections/ansible_collections/prometheus.prometheus-0.29.0.info/GALAXY.yml
+++ b/collections/ansible_collections/prometheus.prometheus-0.29.0.info/GALAXY.yml
@@ -1,8 +1,0 @@
-download_url: https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/prometheus-prometheus-0.29.0.tar.gz
-format_version: 1.0.0
-name: prometheus
-namespace: prometheus
-server: https://galaxy.ansible.com/api/
-signatures: []
-version: 0.29.0
-version_url: /api/v3/plugin/ansible/content/published/collections/index/prometheus/prometheus/versions/0.29.0/

--- a/collections/ansible_collections/prometheus.prometheus-0.29.1.info/GALAXY.yml
+++ b/collections/ansible_collections/prometheus.prometheus-0.29.1.info/GALAXY.yml
@@ -1,0 +1,8 @@
+download_url: https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/prometheus-prometheus-0.29.1.tar.gz
+format_version: 1.0.0
+name: prometheus
+namespace: prometheus
+server: https://galaxy.ansible.com/api/
+signatures: []
+version: 0.29.1
+version_url: /api/v3/plugin/ansible/content/published/collections/index/prometheus/prometheus/versions/0.29.1/

--- a/collections/ansible_collections/prometheus/prometheus/FILES.json
+++ b/collections/ansible_collections/prometheus/prometheus/FILES.json
@@ -851,7 +851,7 @@
    "name": "roles/alertmanager/meta/argument_specs.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "1ecbfc9b78fc0ef581a8d73e16f8f4f3fb7c9dc878b4cdf335fbe7954c26707e",
+   "chksum_sha256": "2996f003f3e4e71fb4227989c2cc4178353fb285e7187aefea3fdf77f5d95e95",
    "format": 1
   },
   {
@@ -865,7 +865,7 @@
    "name": "roles/alertmanager/defaults/main.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "d21f5f4cc4126ea7e94158fce33056a76ace0799f652f6b583c1a5a7140e88ec",
+   "chksum_sha256": "df8527f7ce76b8b6b1019fdc460d81a13f5d9268bc688d9101dd33b8cc134c97",
    "format": 1
   },
   {
@@ -1306,7 +1306,7 @@
    "name": "roles/cadvisor/templates/cadvisor.service.j2",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "ebcd44a116360918c382abe91e64498b88b8055d26e0350744fdc184c5c58ffc",
+   "chksum_sha256": "70b2e9144f38f1073a0f99b110f6cd59fc319c38bbb4f5922a0dc1859c4b9a01",
    "format": 1
   },
   {
@@ -1670,7 +1670,7 @@
    "name": "roles/influxdb_exporter/meta/argument_specs.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "1e60744c0cd5a5bd53c813fe54d35e135da4e6543991226ce254999df76d75ed",
+   "chksum_sha256": "fc023846c0c315e67babae64de7105776df4e6d49d868939e1547056b6e00c92",
    "format": 1
   },
   {
@@ -1684,7 +1684,7 @@
    "name": "roles/influxdb_exporter/defaults/main.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "fa88535358821ba63da07888de7d71f425aeac678eb0ac3b64420829acd6f335",
+   "chksum_sha256": "db6940561976f92d0c2f9edbd785beab13fd8095823e315de38482ca881f4849",
    "format": 1
   },
   {
@@ -2020,7 +2020,7 @@
    "name": "roles/_common/tasks/preflight.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "82a6208c545dbf0259740d5cc8f84720c68d04aad02dd35a57704f8e05a7f930",
+   "chksum_sha256": "cfc1b32e6e3480f0b28b54855e09b964f6d34ab97abd8c4852df0ff3be08a413",
    "format": 1
   },
   {
@@ -2895,7 +2895,7 @@
    "name": "roles/prometheus/meta/argument_specs.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "9ace15e156349983d26ff0bda998e0f74cc64808670afa9d98f01dcd7d0f04f6",
+   "chksum_sha256": "b74ec4dfeb5a57a5c4ff21a653080e9f7d80b9a1769402af8c1a19788ab0ad64",
    "format": 1
   },
   {
@@ -2909,7 +2909,7 @@
    "name": "roles/prometheus/defaults/main.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "7989d5947cdf11069d71eda6a0de26631092333067e7c355f3fcebe5f255ba2b",
+   "chksum_sha256": "dace87a3c7d4d05eee36cea7922d392f7ae376a108bf9a47c2045ef95605d389",
    "format": 1
   },
   {
@@ -3189,7 +3189,7 @@
    "name": "SECURITY.md",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "9508031caf342f4c8d2fc408625bad7acc1afa2e401cc1a6fd59c17b17235148",
+   "chksum_sha256": "1171576cf7b292217f0ddcc513e5a120f41330811a996711986ca2cbd30f89da",
    "format": 1
   },
   {
@@ -3210,7 +3210,7 @@
    "name": "CHANGELOG.rst",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "46cec22c43ec5fcef3c059713c4c9d750095472e979b895493e5fd4dd4e64623",
+   "chksum_sha256": "a51ddd25700483768d755c2d994ffa360a81e77fbbb3423e50b2223ddb990699",
    "format": 1
   },
   {

--- a/collections/ansible_collections/prometheus/prometheus/MANIFEST.json
+++ b/collections/ansible_collections/prometheus/prometheus/MANIFEST.json
@@ -2,7 +2,7 @@
  "collection_info": {
   "namespace": "prometheus",
   "name": "prometheus",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "authors": [
    "Ben Kochie (https://github.com/SuperQ)",
    "Gar\u00f0ar Arnarsson (https://github.com/gardar)",
@@ -34,7 +34,7 @@
   "name": "FILES.json",
   "ftype": "file",
   "chksum_type": "sha256",
-  "chksum_sha256": "c389a01451d15be6153fce16bc492edac03f959dbf7d745d673f3e4368cbb3f3",
+  "chksum_sha256": "63670326eea7716432fabbfe4a56d9e868cf28a97923df0eef304fcbe2b52c8d",
   "format": 1
  },
  "format": 1

--- a/collections/ansible_collections/prometheus/prometheus/roles/_common/tasks/preflight.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/_common/tasks/preflight.yml
@@ -67,6 +67,7 @@
 
 - name: Gather package facts
   ansible.builtin.package_facts:
+    strategy: all
   when: "not 'packages' in ansible_facts"
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"

--- a/collections/ansible_collections/prometheus/prometheus/roles/alertmanager/defaults/main.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/alertmanager/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-alertmanager_version: 0.31.1
+alertmanager_version: 0.32.0
 alertmanager_binary_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/\
                           alertmanager-{{ alertmanager_version }}.{{ ansible_facts['system'] | lower }}-{{ _alertmanager_go_ansible_arch }}.tar.gz"
 alertmanager_checksums_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/sha256sums.txt"

--- a/collections/ansible_collections/prometheus/prometheus/roles/alertmanager/meta/argument_specs.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/alertmanager/meta/argument_specs.yml
@@ -10,7 +10,7 @@ argument_specs:
     options:
       alertmanager_version:
         description: "Alertmanager package version. Also accepts `latest` as parameter."
-        default: 0.31.1
+        default: 0.32.0
       alertmanager_binary_url:
         description: "URL of the alertmanager binaries .tar.gz file"
         default: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.{{ ansible_facts['system'] | lower }}-{{ _alertmanager_go_ansible_arch }}.tar.gz"

--- a/collections/ansible_collections/prometheus/prometheus/roles/cadvisor/templates/cadvisor.service.j2
+++ b/collections/ansible_collections/prometheus/prometheus/roles/cadvisor/templates/cadvisor.service.j2
@@ -28,8 +28,8 @@ ExecStart={{ cadvisor_binary_install_dir }}/cadvisor \
     '--store_container_labels={{ cadvisor_store_container_labels | lower }}' \
     '--listen_ip={{ cadvisor_listen_ip }}' \
     '--port={{ cadvisor_port }}' \
-    '--prometheus_endpoint={{ cadvisor_prometheus_endpoint }}'
-    '--housekeeping_interval={{ cadvisor_housekeeping_interval }}'
+    '--prometheus_endpoint={{ cadvisor_prometheus_endpoint }}' \
+    '--housekeeping_interval={{ cadvisor_housekeeping_interval }}' \
     '--max_housekeeping_interval={{ cadvisor_max_housekeeping_interval }}'
 
 SyslogIdentifier=cadvisor

--- a/collections/ansible_collections/prometheus/prometheus/roles/influxdb_exporter/defaults/main.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/influxdb_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-influxdb_exporter_version: 0.12.0
+influxdb_exporter_version: 0.12.1
 influxdb_exporter_binary_url: "https://github.com/{{ _influxdb_exporter_repo }}/releases/download/v{{ influxdb_exporter_version }}/\
                            influxdb_exporter-{{ influxdb_exporter_version }}.{{ ansible_facts['system'] | lower }}-{{ _influxdb_exporter_go_ansible_arch }}.tar.gz"
 influxdb_exporter_checksums_url: "https://github.com/{{ _influxdb_exporter_repo }}/releases/download/v{{ influxdb_exporter_version }}/sha256sums.txt"

--- a/collections/ansible_collections/prometheus/prometheus/roles/influxdb_exporter/meta/argument_specs.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/influxdb_exporter/meta/argument_specs.yml
@@ -10,7 +10,7 @@ argument_specs:
     options:
       influxdb_exporter_version:
         description: "influxdb exporter package version. Also accepts latest as parameter."
-        default: "0.12.0"
+        default: "0.12.1"
       influxdb_exporter_binary_url:
         description: "URL of the influxdb exporter binaries .tar.gz file"
         default: "https://github.com/{{ _influxdb_exporter_repo }}/releases/download/v{{ influxdb_exporter_version }}/influxdb_exporter-{{ influxdb_exporter_version }}.{{ ansible_facts['system'] | lower }}-{{ _influxdb_exporter_go_ansible_arch }}.tar.gz"

--- a/collections/ansible_collections/prometheus/prometheus/roles/prometheus/defaults/main.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/prometheus/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 3.11.1
+prometheus_version: 3.11.2
 prometheus_binary_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/\
                         prometheus-{{ prometheus_version }}.{{ ansible_facts['system'] | lower }}-{{ _prometheus_go_ansible_arch }}.tar.gz"
 prometheus_checksums_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/sha256sums.txt"

--- a/collections/ansible_collections/prometheus/prometheus/roles/prometheus/meta/argument_specs.yml
+++ b/collections/ansible_collections/prometheus/prometheus/roles/prometheus/meta/argument_specs.yml
@@ -12,7 +12,7 @@ argument_specs:
         description:
           - "Prometheus package version. Also accepts C(latest) as parameter."
           - "Prometheus >= 2.x is supported"
-        default: "3.11.1"
+        default: "3.11.2"
       prometheus_binary_url:
         description: "URL of the prometheus binaries .tar.gz file"
         default: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.{{ ansible_facts['system'] | lower }}-{{ _prometheus_go_ansible_arch }}.tar.gz"

--- a/group_vars/all/cadvisor.yml
+++ b/group_vars/all/cadvisor.yml
@@ -2,7 +2,13 @@
 cadvisor_listen_ip: '[::1]'
 cadvisor_port: 9106
 cadvisor_disable_metrics:
+  - advtcp
   - cpuLoad
+  - cpu_topology
+  - perf_event
+  - referenced_memory
+  - tcp
+  - udp
 
 noisebridge_caddy_cadvisor_route: |
   handle_path /cadvisor/* {


### PR DESCRIPTION
* Bump prometheus collection to pick up cAdvisor unit fix.
* Disable several noisy/expensive cAdvisor metrics features.