### PR TITLE
Add UFW firewall management

### DIFF
--- a/group_vars/all/firewall.yml
+++ b/group_vars/all/firewall.yml
@@ -1,0 +1,3 @@
+prometheus_server_allow:
+- '216.252.162.195'         # m5.noisebridge.net
+- '2602:ff06:725:5:dc::195' # m5.noisebridge.net

--- a/host_vars/m3.noisebridge.net/firewall.yml
+++ b/host_vars/m3.noisebridge.net/firewall.yml
@@ -1,0 +1,8 @@
+---
+noisebridge_host_firewall:
+  - rule: allow
+    name: DNS
+  - rule: allow
+    name: SMTP
+  - rule: allow
+    name: Mail submission

--- a/host_vars/m7.noisebridge.net/firewall.yml
+++ b/host_vars/m7.noisebridge.net/firewall.yml
@@ -1,0 +1,4 @@
+---
+noisebridge_host_firewall:
+  - rule: allow
+    name: DNS

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Allow firewall
+  community.general.ufw:
+    rule: allow
+    name: WWW Full
+
 - name: Install
   ansible.builtin.include_role:
     name: caddy-ansible.caddy-ansible

--- a/roles/security/defaults/main.yml
+++ b/roles/security/defaults/main.yml
@@ -2,3 +2,4 @@
 noisebridge_admins: []
 noisebridge_users: []
 users: []
+noisebridge_host_firewall: []

--- a/roles/security/tasks/firewall.yml
+++ b/roles/security/tasks/firewall.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Allow ssh/mosh
+  community.general.ufw:
+    rule: allow
+    name: "{{ item }}"
+  with_items:
+    - OpenSSH
+    - mosh
+
+- name: Allow Prometheus exporters
+  community.general.ufw:
+    rule: allow
+    proto: tcp
+    to_port: "3903,9100:9299"
+    from_ip: "{{ item }}"
+  with_items: "{{ prometheus_server_allow }}"
+
+- name: Add per-host firewall rules
+  community.general.ufw:
+    comment: "{{ item.comment | default(omit) }}"
+    delete: "{{ item.delete | default(omit) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    from_ip: "{{ item.from_ip | default(omit) }}"
+    from_port: "{{ item.from_port | default(omit) }}"
+    insert: "{{ item.insert | default(omit) }}"
+    interface: "{{ item.interface | default(omit) }}"
+    log: "{{ item.log | default(omit) }}"
+    logging: "{{ item.logging | default(omit) }}"
+    name: "{{ item.name | default(omit) }}"
+    policy: "{{ item.policy | default(omit) }}"
+    proto: "{{ item.proto | default(omit) }}"
+    route: "{{ item.route | default(omit) }}"
+    rule: "{{ item.rule | default(omit) }}"
+    to_ip: "{{ item.to_ip | default(omit) }}"
+    to_port: "{{ item.to_port | default(omit) }}"
+  with_items: "{{ noisebridge_host_firewall }}"

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 
-- import_tasks: users.yml
+- name: Include task users
+  ansible.builtin.include_tasks:
+    file: users.yml
+
+- name: Include task firewall
+  ansible.builtin.include_tasks:
+    file: firewall.yml
 
 - name: Create cert group
   ansible.builtin.group:


### PR DESCRIPTION
Add a set of tasks to the security role to manage UFW rules.
* Allow Prometheus scrapes to a few ports from m5.
* Add SSH/mosh to all hosts.
* Add default HTTP/HTTPS to Caddy role.
* Add some rules for allowing host-specific services.