### PR TITLE
Fix mediawiki timezone

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -101,7 +101,7 @@ $wgShellLocale = "en_US.utf8";
 # Site language code, should be one of the list in ./languages/data/Names.php
 $wgLanguageCode = "en";
 
-$wgLocaltimezone = "US/Pacific";
+$wgLocaltimezone = "America/Los_Angeles";
 date_default_timezone_set( $wgLocaltimezone );
 
 $wgSecretKey = "{{ mediawiki_secret_key }}";
@@ -278,7 +278,7 @@ wfLoadExtension( 'AdminLinks' );
 wfLoadExtension( 'QRLite' );
 
 #Set Default Timezone
-$wgLocaltimezone = "US/Pacific";
+$wgLocaltimezone = "America/Los_Angeles";
 date_default_timezone_set( $wgLocaltimezone );
 
 # https://www.mediawiki.org/wiki/Extension:Scribunto


### PR DESCRIPTION
The timezone ID `US/Pacific` is deprecated in favor of `America/Los_Angeles`