### PR TITLE
wiki: Deploy Anubis in front of wiki to stop AI crawlers

### DIFF
--- a/group_vars/noisebridge_net/anubis.yml
+++ b/group_vars/noisebridge_net/anubis.yml
@@ -1,0 +1,8 @@
+---
+# Anubis configuration for MediaWiki bot protection
+
+anubis_target: "http://127.0.0.1:8080"
+anubis_difficulty: 4
+
+anubis_cookie_domain: ".noisebridge.net"
+anubis_webmaster_email: "webmaster@noisebridge.net"

--- a/roles/anubis/defaults/main.yml
+++ b/roles/anubis/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+anubis_version: "1.25.0"
+anubis_checksum: "sha256:958d17e52e9445a0f60c2f35ab05b7464841e4714d8df6c5ec986800f06471f7"

--- a/roles/anubis/handlers/main.yml
+++ b/roles/anubis/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart anubis
+  ansible.builtin.systemd:
+    name: anubis
+    state: restarted
+    daemon_reload: true

--- a/roles/anubis/tasks/main.yml
+++ b/roles/anubis/tasks/main.yml
@@ -1,0 +1,86 @@
+---
+# Anubis - bot protection for MediaWiki
+
+- name: Create anubis system group
+  ansible.builtin.group:
+    name: anubis
+    system: true
+    state: present
+
+- name: Create anubis system user
+  ansible.builtin.user:
+    name: anubis
+    system: true
+    shell: "/sbin/nologin"
+    group: anubis
+    createhome: false
+
+- name: Create anubis config directory
+  ansible.builtin.file:
+    path: /etc/anubis
+    state: directory
+    owner: anubis
+    group: anubis
+    mode: "0755"
+
+- name: Add www-data to anubis group for socket access
+  ansible.builtin.user:
+    name: www-data
+    groups: anubis
+    append: true
+
+- name: Download anubis tarball
+  ansible.builtin.get_url:
+    url: "https://github.com/TecharoHQ/anubis/releases/download/v{{ anubis_version }}/anubis-{{ anubis_version }}-linux-amd64.tar.gz"
+    dest: "/var/cache/anubis-{{ anubis_version }}.tar.gz"
+    checksum: "{{ anubis_checksum }}"
+    mode: "0644"
+
+- name: Extract anubis binary
+  ansible.builtin.unarchive:
+    src: "/var/cache/anubis-{{ anubis_version }}.tar.gz"
+    dest: /var/cache
+    remote_src: true
+    creates: "/var/cache/anubis-{{ anubis_version }}-linux-amd64/bin/anubis"
+
+- name: Install anubis binary
+  ansible.builtin.copy:
+    src: "/var/cache/anubis-{{ anubis_version }}-linux-amd64/bin/anubis"
+    dest: "/usr/local/bin/anubis-{{ anubis_version }}"
+    remote_src: true
+    mode: "0755"
+    owner: root
+    group: root
+  notify: Restart anubis
+
+- name: Symlink anubis binary
+  ansible.builtin.file:
+    src: "/usr/local/bin/anubis-{{ anubis_version }}"
+    dest: /usr/local/bin/anubis
+    state: link
+  notify: Restart anubis
+
+- name: Deploy anubis policy configuration
+  ansible.builtin.template:
+    src: policy.yaml.j2
+    dest: /etc/anubis/policy.yaml
+    owner: anubis
+    group: anubis
+    mode: "0644"
+  notify: Restart anubis
+
+- name: Create anubis systemd service
+  ansible.builtin.template:
+    src: anubis.service.j2
+    dest: /etc/systemd/system/anubis.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart anubis
+
+- name: Ensure anubis service is started and enabled
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: anubis
+    state: started
+    enabled: true

--- a/roles/anubis/templates/anubis.service.j2
+++ b/roles/anubis/templates/anubis.service.j2
@@ -1,0 +1,33 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Anubis bot protection
+After=network.target
+
+[Service]
+Type=simple
+User=anubis
+Group=anubis
+RuntimeDirectory=anubis
+RuntimeDirectoryMode=0755
+
+Environment=BIND=unix//run/anubis/anubis.sock
+Environment=BIND_NETWORK=unix
+Environment=SOCKET_MODE=0660
+Environment=TARGET={{ anubis_target }}
+Environment=DIFFICULTY={{ anubis_difficulty }}
+Environment=METRICS_BIND=:9091
+Environment=POLICY_FNAME=/etc/anubis/policy.yaml
+{% if anubis_cookie_domain is defined %}
+Environment=COOKIE_DOMAIN={{ anubis_cookie_domain }}
+{% endif %}
+{% if anubis_webmaster_email is defined %}
+Environment=WEBMASTER_EMAIL={{ anubis_webmaster_email }}
+{% endif %}
+
+ExecStart=/usr/local/bin/anubis
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/anubis/templates/anubis.service.j2
+++ b/roles/anubis/templates/anubis.service.j2
@@ -11,7 +11,7 @@ Group=anubis
 RuntimeDirectory=anubis
 RuntimeDirectoryMode=0755
 
-Environment=BIND=unix//run/anubis/anubis.sock
+Environment=BIND=/run/anubis/anubis.sock
 Environment=BIND_NETWORK=unix
 Environment=SOCKET_MODE=0660
 Environment=TARGET={{ anubis_target }}

--- a/roles/anubis/templates/policy.yaml.j2
+++ b/roles/anubis/templates/policy.yaml.j2
@@ -1,0 +1,22 @@
+{{ ansible_managed | comment }}
+# Anubis Bot Policy Configuration
+
+bots:
+  # import default AI bot catchall rules
+  - import: "(data)/bots/ai-catchall.yaml"
+
+  # allow those physically at Noisebridge to browse without challenges
+  - name: noisebridge-building
+    remote_addresses:
+      - "192.195.83.128/29"
+    action: ALLOW
+
+  # allow legitimate search engines
+  - name: search-engines
+    user_agent_regex: "(?i)googlebot|bingbot|duckduckbot"
+    action: ALLOW
+
+  # allow Internet Archive
+  - name: internet-archive
+    user_agent_regex: "(?i)archive\\.org_bot|ia_archiver"
+    action: ALLOW

--- a/site.yml
+++ b/site.yml
@@ -39,6 +39,7 @@
     - { role: safespace, tags: ["safespace"] }
     - { role: mydumper, tags: ["mydumper"] }
     - { role: prometheus.prometheus.mysqld_exporter, tags: ["mysqld_exporter"] }
+    - { role: anubis, tags: ["anubis"] }
     - { role: caddy, tags: ["caddy"] }
     - { role: oomadj, tags: ["oomadj"] }
 

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -49,6 +49,7 @@
   rewrite / /index.php?title={path}
   redir / /wiki
 }
+
 # Metrics server
 {{ ansible_fqdn }} {
   handle_path /goaccess/* {

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -3,24 +3,54 @@
 {
   order cgi last
 
-  # TODO ratelimit incl somewhere here
-
-  # TODO want:  cache before rate_limit
-  #order file_server before rate_limit
-  #order rate_limit after file_server
-
   {{ noisebridge_caddy_global_security | indent(width=2) }}
   {{ noisebridge_caddy_global_metrics | indent(width=2) }}
 }
-# Metrics server
-{{ ansible_fqdn }} {
-  handle_path /anubis/* {
-    reverse_proxy {
-        to unix//var/run/anubis/anubis-public.sock
-        header_up X-Forwarded-Prefix /anubis
+
+# Internal MediaWiki backend (used by Anubis)
+# This serves MediaWiki via PHP-FPM on localhost only
+:8080 {
+  bind 127.0.0.1
+
+  root * /srv/mediawiki/noisebridge.net-1.39.13
+
+  @images {
+    file
+    path *.jpg *.jpeg *.png *.gif *.webp *.svg
+  }
+  header @images Cache-Control "public, max-age=600, must-revalidate"
+
+  route /images* {
+    uri strip_prefix /images
+    file_server {
+      root /srv/mediawiki/noisebridge.net/images
+    }
+  }
+  route /img* {
+    uri strip_prefix /images
+    file_server {
+      root /srv/mediawiki/noisebridge.net/img
     }
   }
 
+  @favicon path /favicon.ico
+  handle @favicon {
+    file_server {
+      root /srv/mediawiki/noisebridge.net/img
+    }
+  }
+
+  php_fastcgi unix//run/php/php8.2-fpm.sock
+  file_server {
+    hide *.php
+  }
+
+  # MediaWiki URL rewriting - converts /wiki/Page_Name to index.php
+  rewrite / /index.php?title={path}
+  redir / /wiki
+}
+# Metrics server
+{{ ansible_fqdn }} {
   handle_path /goaccess/* {
     basic_auth {
       nb {{ noisebridge_goaccess_basic_auth }}
@@ -78,7 +108,7 @@ noisebridge.org, www.noisebridge.org {
   redir https://www.noisebridge.net{uri}
 }
 
-# Mediawiki
+# Mediawiki - proxied through Anubis for bot/scraper protection
 www.noisebridge.net {
   log {
     output file "{{ caddy_log_dir }}/www.noisebridge.net.log" {
@@ -88,180 +118,34 @@ www.noisebridge.net {
   }
   {{ noisebridge_caddy_secure_header | indent(width=2) }}
 
-  @claudebot {
-    header User-Agent *ClaudeBot*
-  }
-  respond @claudebot 403
-
-  @images {
-    file
-    path *.jpg *.jpeg *.png *.gif *.webp *.svg
-  }
-  header @images Cache-Control "public, max-age=600, must-revalidate"
-
-  route /images* {
-    uri strip_prefix /images
-    file_server {
-      root /srv/mediawiki/noisebridge.net/images
-    }
-  }
-  route /img* {
-    uri strip_prefix /images
-    file_server {
-      root /srv/mediawiki/noisebridge.net/img
+  # Anubis challenge assets (served directly from Anubis)
+  handle /.within.website/* {
+    reverse_proxy unix//run/anubis/anubis.sock {
+      header_up X-Real-IP {remote_host}
+      header_up X-Forwarded-For {remote_host}
+      header_up X-Forwarded-Proto {scheme}
     }
   }
 
-  # NOTE: rate limits match in order
-  @heavy path /api.php /wiki/Special:* /wiki/Special:MobileDiff* /index.php?days=14* /index.php?*title=Special%3ARecentChanges* /index.php?*title=Special:RecentChanges* /index.php?*returnto=Special%3ARecentChanges* /index.php?*veaction=edit*
-  #/index.php?*
-  #@heavy path /api.php /wiki/Special:* 
-
-  #/index.php?days=14*
-  #/index.php?*title=Special%3ARecentChanges*
-  #/index.php?*title=Special:RecentChanges*
-  #/index.php?*
-  #/index.php?*returnto=Special%3ARecentChanges*
-  #/wiki/Special:MobileDiff*
-  #/wiki  index.php ... redirect Special
-
-  @bot header_regexp User-Agent (?i)bot
-  route @bot {
-    rate_limit {
-      zone bots {
-        key {remote_ip}
-        events 5
-        window 1m
-
-      }
-    }
-    php_fastcgi unix//run/php/php8.2-fpm.sock ## FIXME -- invoked in each rate limit scope [1/3]
-  }
-
-  route @heavy {
-    rate_limit {
-      # for [nb]: allow [1000] req / [5s]
-      zone nb_zone {
-        key {remote_ip}
-        match {
-          remote_ip 192.195.83.130 # Noisebridge-Monkeybrains SF space IP
-        }
-        events 1000
-        window 5s
-      }
-      zone anon_zone {
-        match {
-          not {
-            remote_ip 192.195.83.130 # Noisebridge-Monkeybrains SF space IP
-            #header Cookie wiki_wiki_User*
-            #header Authorization Basic* # easy to guess, not relevant?  hack of bypass for curl/API use?
-          }
-        }
-        #key {client_ip /24} # smallest routeable ip block, still, too small to even likely catch within-cloud ip variation
-        key {remote_ip}
-        events 25 # superq 2026-04-13
-        #events 75 # 50 # 25 # 20 (ok~), 15, 10 2026-02-16 # 5 @ 2026-02-15 # growing from left
-        #events 5 # 50 # 25 # 20 (ok~), 15, 10 2026-02-16 # 5 @ 2026-02-15 # growing from left
-        # 72 required to load the home page, logged in
-        # 46 required to load the home page, anon
-        #window 5s
-        window 10s
-      }
-    }
-    php_fastcgi unix//run/php/php8.2-fpm.sock ## FIXME -- invoked in each rate limit scope [2/3]
-  }
-
-  route {
-    rate_limit {
-      # for [nb]: allow [1000] req / [5s]
-      zone nb_zone {
-        key {remote_ip}
-        match {
-          remote_ip 192.195.83.130 # Noisebridge-Monkeybrains SF space IP
-        }
-        events 1000
-        window 5s
-      }
-
-      zone user_zone {
-        match {
-          header Cookie wiki_wiki_UserID=* #; wiki_wiki__session=*
-          # logged out user gets: wiki_wiki_mwuser-sessionId=fd49f9679fe28031d2dd
-            #not{
-            #!remote_ip 192.195.83.130 # Noisebridge-Monkeybrains SF space IP
-            #!header Cookie wiki_wiki_s*
-            #!header Authorization Basic* # easy to guess, not relevant?  hack of bypass for curl/API use?
-            #}
-        }
-        key {http.request.cookie.mw_session}
-        #events 150
-        events 300
-        window 5s
-        # 72 required to load the home page, logged in
-        # 46 required to load the home page, anon
-        # 20 (ok~), 15, 10 2026-02-16 # 5 @ 2026-02-15 # growing from left
-      }
-
-      zone anon_zone {
-        match {
-          not {
-            remote_ip 192.195.83.130 # Noisebridge-Monkeybrains SF space IP
-            #header Cookie wiki_wiki_User*
-            #header Authorization Basic* # easy to guess, not relevant?  hack of bypass for curl/API use?
-          }
-        }
-        key {client_ip /24} # smallest routeable ip block, still, too small to even likely catch within-cloud ip variation
-        events 75 # 50 # 25 # 20 (ok~), 15, 10 2026-02-16 # 5 @ 2026-02-15 # growing from left
-        #events 25 # 50 # 25 # 20 (ok~), 15, 10 2026-02-16 # 5 @ 2026-02-15 # growing from left
-        # 72 required to load the home page, logged in
-        # 46 required to load the home page, anon
-        #window 5s
-        window 10s
-      }
-
-      # User Agent: facebook / meta dev
-      zone bot_zone {
-        match {
-          #import allowed 
-          #not {
-          header User-Agent meta-externalagent/1.1*
-            #header Authorization Basic* # easy to guess, not relevant?  hack of bypass for curl/API use?
-          #}
-        }
-        key {client_ip /24} # smallest routeable ip block, still, too small to even likely catch within-cloud ip variation
-        events 1
-        window 5s
-      }
-
-    }
-    php_fastcgi unix//run/php/php8.2-fpm.sock ## FIXME -- invoked in each rate limit scope [3/3]
-  }
-
-  root * /srv/mediawiki/noisebridge.net-1.39.13
-  # php_fastcgi unix//run/php/php8.2-fpm.sock ## FIXME -- invoked in each rate limit scope - [orig]
-  file_server {
-    hide *.php
-  }
-
-  @favicon path /favicon.ico
-  handle @favicon {
-    file_server {
-      root /srv/mediawiki/noisebridge.net/img
-    }
-  }
-  
+  # Adminer - bypass Anubis, requires GitHub auth
   route /adminer* {
     authorize with noisebridge-github-rack
     root * /srv/adminer
     try_files {path} adminer.php
+    php_fastcgi unix//run/php/php8.2-fpm.sock
   }
 
   # Legacy mailman redirects
   redir /pipermail https://lists.noisebridge.net{uri}
   redir /mailman https://lists.noisebridge.net{uri}
 
-  rewrite / /index.php?title={path}
-  redir / /wiki
+  # All other traffic goes through Anubis
+  reverse_proxy unix//run/anubis/anubis.sock {
+    header_up X-Real-IP {remote_host}
+    header_up X-Forwarded-For {remote_host}
+    header_up X-Forwarded-Proto {scheme}
+    header_up Host {host}
+  }
 }
 
 # Mailman


### PR DESCRIPTION
Replace the Caddy rate limiting of AI crawlers with an instance of Anubis which will force clients to perform a proof-of-work challenge accessible only to browser-based clients.

This should hopefully prevent AI bots from giving the wiki the hug of death while permitting well-behaved search engine and wayback machine crawlers to pass.

Signed-off-by: Patrick O'Doherty <hello@patrickod.com>