### PR TITLE
Update Anubis config

### DIFF
--- a/group_vars/m5_noisebridge_net/prometheus.yml
+++ b/group_vars/m5_noisebridge_net/prometheus.yml
@@ -34,6 +34,14 @@ prometheus_scrape_configs:
           - "m5.noisebridge.net:9100"
           - "m6.noisebridge.net:9100"
           - "m7.noisebridge.net:9100"
+  - job_name: anubis
+    # scheme: https
+    # basic_auth:
+    #   username: prometheus
+    #   password: "{{ noisebridge_prometheus_password }}"
+    static_configs:
+      - targets:
+          - "m3.noisebridge.net:9103"
   - job_name: "caddy"
     scheme: https
     basic_auth:

--- a/group_vars/noisebridge_net/anubis.yml
+++ b/group_vars/noisebridge_net/anubis.yml
@@ -6,3 +6,6 @@ anubis_difficulty: 4
 
 anubis_cookie_domain: ".noisebridge.net"
 anubis_webmaster_email: "webmaster@noisebridge.net"
+
+anubis_metrics_username: "prometheus"
+anubis_metrics_password: "{{ noisebridge_prometheus_password }}"

--- a/roles/anubis/defaults/main.yml
+++ b/roles/anubis/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 anubis_version: "1.25.0"
 anubis_checksum: "sha256:958d17e52e9445a0f60c2f35ab05b7464841e4714d8df6c5ec986800f06471f7"
+
+anubis_metrics_bind: ":9103"
+anubis_metrics_username: "prometheus"
+anubis_metrics_password: "Secret"

--- a/roles/anubis/tasks/main.yml
+++ b/roles/anubis/tasks/main.yml
@@ -29,6 +29,12 @@
     groups: anubis
     append: true
 
+- name: Add anubis to ssl-cert group for TLS listening
+  ansible.builtin.user:
+    name: anubis
+    groups: ssl-cert
+    append: true
+
 - name: Download anubis tarball
   ansible.builtin.get_url:
     url: "https://github.com/TecharoHQ/anubis/releases/download/v{{ anubis_version }}/anubis-{{ anubis_version }}-linux-amd64.tar.gz"

--- a/roles/anubis/templates/anubis.service.j2
+++ b/roles/anubis/templates/anubis.service.j2
@@ -16,8 +16,7 @@ Environment=BIND_NETWORK=unix
 Environment=SOCKET_MODE=0660
 Environment=TARGET={{ anubis_target }}
 Environment=DIFFICULTY={{ anubis_difficulty }}
-Environment=METRICS_BIND=:9091
-Environment=POLICY_FNAME=/etc/anubis/policy.yaml
+Environment=METRICS_BIND=:9103
 {% if anubis_cookie_domain is defined %}
 Environment=COOKIE_DOMAIN={{ anubis_cookie_domain }}
 {% endif %}
@@ -25,7 +24,7 @@ Environment=COOKIE_DOMAIN={{ anubis_cookie_domain }}
 Environment=WEBMASTER_EMAIL={{ anubis_webmaster_email }}
 {% endif %}
 
-ExecStart=/usr/local/bin/anubis
+ExecStart=/usr/local/bin/anubis -policy-fname=/etc/anubis/policy.yaml
 Restart=always
 RestartSec=5
 

--- a/roles/anubis/templates/policy.yaml.j2
+++ b/roles/anubis/templates/policy.yaml.j2
@@ -1,22 +1,108 @@
 {{ ansible_managed | comment }}
 # Anubis Bot Policy Configuration
 
-bots:
-  # import default AI bot catchall rules
-  - import: "(data)/bots/ai-catchall.yaml"
+# This will be in Anubis >= 1.26.0.
+# metrics:
+#   bind: "{{ anubis_metrics_bind }}"
+#   network: tcp
+#   tls:
+#     certificate: "/etc/ssl/{{ ansible_fqdn }}/{{ ansible_fqdn }}.crt"
+#     key: "/etc/ssl/{{ ansible_fqdn }}/{{ ansible_fqdn }}.key"
+#   basicAuth:
+#     username: "{{ anubis_metrics_username }}"
+#     password: "{{ anubis_metrics_password }}"
 
+bots:
   # allow those physically at Noisebridge to browse without challenges
   - name: noisebridge-building
     remote_addresses:
       - "192.195.83.128/29"
     action: ALLOW
 
-  # allow legitimate search engines
-  - name: search-engines
-    user_agent_regex: "(?i)googlebot|bingbot|duckduckbot"
+  - name: m5.noisebridge.net
+    remote_addresses:
+      - "216.252.162.195/32"
+      - "2602:ff06:725:5:dc::195/128"
     action: ALLOW
 
-  # allow Internet Archive
-  - name: internet-archive
-    user_agent_regex: "(?i)archive\\.org_bot|ia_archiver"
-    action: ALLOW
+  # This section imports the default config.
+  # See: https://github.com/TecharoHQ/anubis/blob/main/data/meta/default-config.yaml
+  - # Pathological bots to deny
+    # This correlates to data/bots/_deny-pathological.yaml in the source tree
+    # https://github.com/TecharoHQ/anubis/blob/main/data/bots/_deny-pathological.yaml
+    import: (data)/bots/_deny-pathological.yaml
+  - import: (data)/bots/aggressive-brazilian-scrapers.yaml
+
+  # Aggressively block AI/LLM related bots/agents by default
+  # - import: (data)/meta/ai-block-aggressive.yaml
+
+  # Consider replacing the aggressive AI policy with more selective policies:
+  - import: (data)/meta/ai-block-moderate.yaml
+  # - import: (data)/meta/ai-block-permissive.yaml
+
+  # Search engine crawlers to allow, defaults to:
+  #   - Google (so they don't try to bypass Anubis)
+  #   - Apple
+  #   - Bing
+  #   - DuckDuckGo
+  #   - Qwant
+  #   - The Internet Archive
+  #   - Kagi
+  #   - Marginalia
+  #   - Mojeek
+  - import: (data)/crawlers/_allow-good.yaml
+  # Challenge Firefox AI previews
+  - import: (data)/clients/x-firefox-ai.yaml
+
+  # Allow common "keeping the internet working" routes (well-known, favicon, robots.txt)
+  - import: (data)/common/keep-internet-working.yaml
+
+  # Requires a subscription to Thoth to use, see
+  # https://anubis.techaro.lol/docs/admin/thoth#geoip-based-filtering
+  # - name: countries-with-aggressive-scrapers
+  #   action: WEIGH
+  #   geoip:
+  #     countries:
+  #       - BR
+  #       - CN
+  #   weight:
+  #     adjust: 10
+
+  # Requires a subscription to Thoth to use, see
+  # https://anubis.techaro.lol/docs/admin/thoth#asn-based-filtering
+  # - name: aggressive-asns-without-functional-abuse-contact
+  #   action: WEIGH
+  #   asns:
+  #     match:
+  #       - 13335 # Cloudflare
+  #       - 136907 # Huawei Cloud
+  #       - 45102 # Alibaba Cloud
+  #   weight:
+  #     adjust: 10
+
+  # ## System load based checks.
+  # # If the system is under high load, add weight.
+  # - name: high-load-average
+  #   action: WEIGH
+  #   expression: load_1m >= 10.0 # make sure to end the load comparison in a .0
+  #   weight:
+  #     adjust: 20
+
+  ## If your backend service is running on the same operating system as Anubis,
+  ## you can uncomment this rule to make the challenge easier when the system is
+  ## under low load.
+  ##
+  ## If it is not, remove weight.
+  # - name: low-load-average
+  #   action: WEIGH
+  #   expression: load_15m <= 4.0 # make sure to end the load comparison in a .0
+  #   weight:
+  #     adjust: -10
+
+  # Generic catchall rule
+  - name: generic-browser
+    user_agent_regex: >-
+      Mozilla|Opera
+    action: WEIGH
+    weight:
+      adjust: 10


### PR DESCRIPTION
* Change metrics port to 9103 so it lands in the standard metrics firewall rules.
* Setup, but not enable, TLS/auth (not released yet) for metrics.
* Use the Anubis default config to configure various sane defaults.