### PR TITLE
Add wiki_dumps role: daily public MediaWiki export

### DIFF
--- a/roles/wiki_dumps/defaults/main.yml
+++ b/roles/wiki_dumps/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+wiki_dumps_mediawiki_path: "/srv/mediawiki/{{ mediawiki.domain }}"
+wiki_dumps_localsettings: "/srv/mediawiki/{{ mediawiki.domain }}/LocalSettings.php"
+
+# Public dump — current revisions of public pages only, served to bots
+wiki_dumps_public_dir: /var/www/dumps.noisebridge.net
+wiki_dumps_public_keep_days: 7
+
+# Cron schedule (default: 2AM daily)
+wiki_dumps_cron_hour: 2
+wiki_dumps_cron_minute: 0

--- a/roles/wiki_dumps/files/wiki_dump.sh
+++ b/roles/wiki_dumps/files/wiki_dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generates a public MediaWiki dump (current revisions, public pages only)
 # for bot/scraper consumption at dumps.noisebridge.net
 
@@ -7,6 +7,10 @@ set -euo pipefail
 MEDIAWIKI_PATH="${MEDIAWIKI_PATH:-/srv/mediawiki/noisebridge.net}"
 LOCALSETTINGS="${LOCALSETTINGS:-/srv/mediawiki/noisebridge.net/LocalSettings.php}"
 PUBLIC_DIR="${PUBLIC_DIR:-/var/www/dumps.noisebridge.net}"
+if [[ ! -d "${PUBLIC_DIR}" ]]; then
+  echo "ERROR: Missing directory: '${PUBLIC_DIR}'"
+  exit 1
+fi
 PUBLIC_KEEP_DAYS="${PUBLIC_KEEP_DAYS:-7}"
 
 PHP="${PHP:-php}"

--- a/roles/wiki_dumps/files/wiki_dump.sh
+++ b/roles/wiki_dumps/files/wiki_dump.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Generates a public MediaWiki dump (current revisions, public pages only)
+# for bot/scraper consumption at dumps.noisebridge.net
+
+set -euo pipefail
+
+MEDIAWIKI_PATH="${MEDIAWIKI_PATH:-/srv/mediawiki/noisebridge.net}"
+LOCALSETTINGS="${LOCALSETTINGS:-/srv/mediawiki/noisebridge.net/LocalSettings.php}"
+PUBLIC_DIR="${PUBLIC_DIR:-/var/www/dumps.noisebridge.net}"
+PUBLIC_KEEP_DAYS="${PUBLIC_KEEP_DAYS:-7}"
+
+PHP="${PHP:-php}"
+TS=$(date -u '+%Y%m%d')
+OUTFILE="${PUBLIC_DIR}/noisebridge-${TS}-public.xml.gz"
+
+echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Starting public dump -> ${OUTFILE}"
+"${PHP}" "${MEDIAWIKI_PATH}/maintenance/dumpBackup.php" \
+  --conf "${LOCALSETTINGS}" \
+  --current --public \
+  --output "gzip:${OUTFILE}.tmp"
+mv "${OUTFILE}.tmp" "${OUTFILE}"
+ln -sf "${OUTFILE}" "${PUBLIC_DIR}/latest.xml.gz"
+echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Completed dump ($(du -sh "${OUTFILE}" | cut -f1))"
+
+find "${PUBLIC_DIR}" -name 'noisebridge-*-public.xml.gz' -mtime "+${PUBLIC_KEEP_DAYS}" -delete
+
+echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Done."

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create public dump directory
+  ansible.builtin.file:
+    path: "{{ wiki_dumps_public_dir }}"
+    state: directory
+    owner: "{{ mediawiki.system_user }}"
+    group: "{{ mediawiki.system_group }}"
+    mode: "0755"
+
+- name: Deploy dump script
+  ansible.builtin.copy:
+    src: wiki_dump.sh
+    dest: /usr/local/sbin/wiki_dump
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Install cron job
+  ansible.builtin.cron:
+    name: MediaWiki public dump
+    cron_file: wiki_dump
+    user: "{{ mediawiki.system_user }}"
+    hour: "{{ wiki_dumps_cron_hour }}"
+    minute: "{{ wiki_dumps_cron_minute }}"
+    job: >-
+      MEDIAWIKI_PATH={{ wiki_dumps_mediawiki_path }}
+      LOCALSETTINGS={{ wiki_dumps_localsettings }}
+      PUBLIC_DIR={{ wiki_dumps_public_dir }}
+      PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
+      /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -27,4 +27,5 @@
       LOCALSETTINGS={{ wiki_dumps_localsettings }}
       PUBLIC_DIR={{ wiki_dumps_public_dir }}
       PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
+      PHP=/usr/bin/php8.2
       /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1

--- a/site.yml
+++ b/site.yml
@@ -40,6 +40,7 @@
     - { role: mydumper, tags: ["mydumper"] }
     - { role: prometheus.prometheus.mysqld_exporter, tags: ["mysqld_exporter"] }
     - { role: anubis, tags: ["anubis"] }
+    - { role: wiki_dumps, tags: ["wiki_dumps"] }
     - { role: caddy, tags: ["caddy"] }
     - { role: oomadj, tags: ["oomadj"] }
 

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -225,3 +225,16 @@ safespace.noisebridge.net {
   root * /var/www/safespace.noisebridge.net
   php_fastcgi unix//run/php/php8.2-fpm.sock
 }
+
+# Wiki dumps (public, for bot consumption)
+dumps.noisebridge.net {
+  log {
+    output file "{{ caddy_log_dir }}/dumps.noisebridge.net.log" {
+      {{ noisebridge_caddy_log_roll | indent(width=6) }}
+    }
+  {{ noisebridge_caddy_log_filter | indent(width=4) }}
+  }
+  {{ noisebridge_caddy_secure_header | indent(width=2) }}
+  root * {{ wiki_dumps_public_dir }}
+  file_server browse
+}


### PR DESCRIPTION
## Summary

- Adds a `wiki_dumps` Ansible role that runs a nightly `dumpBackup.php` job on m3
- Public dump only (`--current --public`): current revisions of public pages, kept 7 days, served at `dumps.noisebridge.net`
- No image uploads included — dumps are for bots, not for us (we use the API)
- Gives scrapers a structured download target instead of hammering the live wiki

Ref noisebridge/noisebridge-wiki#3

## Changes

- `roles/wiki_dumps/` — new role (defaults, tasks, shell script)
- `templates/caddy/m3/Caddyfile.j2` — adds `dumps.noisebridge.net` file server block
- `site.yml` — wires role into the m3 play (before caddy)

## Deploy

After merge:
```
ansible-playbook site.yml --limit m3.noisebridge.net -t wiki_dumps,caddy
```

**Note:** `dumps.noisebridge.net` needs a DNS A record pointing to m3 before Caddy can obtain a cert.