### PR TITLE
dns: add dumps.noisebridge.net CNAME to m3

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026032800 ; Serial
+                                2026050500 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -165,6 +165,7 @@ pegasus         IN      AAAA    2607:f598:b0cf:200:250:c2ff:fe28:3070
 pegasus         IN      A       192.195.83.134
 
 ; Services hosted on m3
+dumps           IN      CNAME   m3
 safespace       IN      CNAME   m3
 
 ; Services hosted on m5


### PR DESCRIPTION
## Summary

Adds `dumps.noisebridge.net` as a CNAME to m3, required for Caddy to obtain a TLS cert for the wiki dumps file server introduced in #506.

## Changes

- `files/coredns/zones/noisebridge.net` — new CNAME entry, bumped serial to 2026050500

## Deploy

```
ansible-playbook site.yml --limit m3.noisebridge.net,dns -t dns,caddy
```

Should be merged and deployed before or alongside #506.