### PR TITLE
wiki_dumps: update Noisebridge address to 272 Capp Street

### DIFF
--- a/roles/wiki_dumps/files/site/index.html
+++ b/roles/wiki_dumps/files/site/index.html
@@ -501,7 +501,7 @@
     <h2>ABOUT NOISEBRIDGE</h2>
 
     <p itemprop="description">
-      <strong itemprop="name">Noisebridge</strong> is a do-ocratic hackerspace in San Francisco, California. Founded in 2007, it operates out of 2169 Mission Street, 3rd floor. Open 24/7. The operating principle: anyone can do anything that is excellent — no permission required.
+      <strong itemprop="name">Noisebridge</strong> is a do-ocratic hackerspace in San Francisco, California. Founded in 2007, it operates out of 272 Capp Street. Open 24/7. The operating principle: anyone can do anything that is excellent — no permission required.
     </p>
 
     <p>
@@ -517,7 +517,7 @@
     </p>
 
     <p style="margin-top: 1rem; font-size: 11px; color: #504030;">
-      Page last updated: May 7, 2026
+      Page last updated: May 15, 2026
     </p>
   </div>
 


### PR DESCRIPTION
## Summary
- Update address from old location (2169 Mission Street) to current location (272 Capp Street)
- Update page last updated date

Deploy: `ansible-playbook site.yml --limit m3.noisebridge.net -t wiki_dumps`