### PR TITLE
caddy: run caddy fmt --overwrite after config deploy

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -8,6 +8,11 @@
   ansible.builtin.include_role:
     name: caddy-ansible.caddy-ansible
 
+- name: Format Caddyfile
+  ansible.builtin.command:
+    cmd: caddy fmt --overwrite /etc/caddy/Caddyfile
+  changed_when: false
+
 - name: Install jq
   become: true
   ansible.builtin.package:


### PR DESCRIPTION
## Summary
- Run `caddy fmt --overwrite` after Caddyfile is deployed, before reload
- Eliminates log spam about inconsistent formatting on every reload

Closes #463

Deploy: `ansible-playbook site.yml --limit m3.noisebridge.net -t caddy`

_took a stab, wasn't sure if there was some kind of complication, please advise_