### PR TITLE
Fixup m6 caddy

### DIFF
--- a/group_vars/all/caddy.yml
+++ b/group_vars/all/caddy.yml
@@ -9,44 +9,49 @@ noisebridge_github_client_id: "{{ vault_noisebridge_github_client_id }}"
 noisebridge_github_client_secret: "{{ vault_noisebridge_github_client_secret }}"
 noisebridge_jwt_token_secret: "{{ vault_noisebridge_jwt_token_secret }}"
 
-noisebridge_caddy_global_security: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_global_security: |-
   order authenticate before respond
-  order authorize before basic_auth
-  security {
-    authorization policy noisebridge-github-rack {
-      set auth url https://auth.noisebridge.net/auth
-      crypto key verify {{ noisebridge_jwt_token_secret }}
-      crypto key token name access_token
-      allow roles members rack
-      inject headers with claims
-    }
-  }
+  	order authorize before basic_auth
+  	security {
+  		authorization policy noisebridge-github-rack {
+  			set auth url https://auth.noisebridge.net/auth
+  			crypto key verify {{ noisebridge_jwt_token_secret }}
+  			crypto key token name access_token
+  			allow roles members rack
+  			inject headers with claims
+  		}
+  	}
 
-noisebridge_caddy_global_metrics: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_global_metrics: |-
   metrics {
-    per_host
-  }
+  		per_host
+  	}
 
-noisebridge_caddy_log_filter: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_log_filter: |-
   format filter {
-    wrap json
-    fields {
-      common_log delete
-      request>remote_addr ip_mask {
-        ipv4 16
-        ipv6 64
-      }
-    }
-  }
+  			wrap json
+  			fields {
+  				common_log delete
+  				request>remote_addr ip_mask {
+  					ipv4 16
+  					ipv6 64
+  				}
+  			}
+  		}
 
-noisebridge_caddy_secure_header: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_secure_header: |-
   header {
-    Strict-Transport-Security "max-age=31536000;includeSubdomains"
-    X-XSS-Protection "1; mode=block"
-    X-Content-Type-Options "nosniff"
-  }
+  		Strict-Transport-Security "max-age=31536000;includeSubdomains"
+  		X-XSS-Protection "1; mode=block"
+  		X-Content-Type-Options "nosniff"
+  	}
 
-noisebridge_caddy_log_roll: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_log_roll: |-
   roll_keep 520
-  roll_keep_for 7d
-  roll_size 50MiB
+  			roll_keep_for 7d
+  			roll_size 50MiB

--- a/group_vars/all/cadvisor.yml
+++ b/group_vars/all/cadvisor.yml
@@ -10,10 +10,11 @@ cadvisor_disable_metrics:
   - tcp
   - udp
 
-noisebridge_caddy_cadvisor_route: |
+# Note the use of tabs in this var to make Caddyfile formatting happy.
+noisebridge_caddy_cadvisor_route: |-
   handle_path /cadvisor/* {
-    basic_auth {
-      prometheus {{ noisebridge_prometheus_password_hash }}
-    }
-    reverse_proxy [::1]:9106
-  }
+  		basic_auth {
+  			prometheus {{ noisebridge_prometheus_password_hash }}
+  		}
+  		reverse_proxy [::1]:9106
+  	}

--- a/templates/caddy/m6/Caddyfile.j2
+++ b/templates/caddy/m6/Caddyfile.j2
@@ -1,38 +1,39 @@
 {{ ansible_managed | comment }}
 # Global config
 {
-  {{ noisebridge_caddy_global_security | indent(width=2) }}
-  {{ noisebridge_caddy_global_metrics | indent(width=2) }}
+	{{ noisebridge_caddy_global_metrics }}
 }
+
 # Metrics server
 {{ ansible_fqdn }} {
-  route /metrics {
-    basic_auth {
-      prometheus {{ noisebridge_prometheus_password_hash }}
-    }
-    metrics
-  }
-  {{ noisebridge_caddy_cadvisor_route | indent(width=2) }}
-  respond "Noisebridge Infrastructure - {{ ansible_fqdn }}"
+	route /metrics {
+		basic_auth {
+			prometheus {{ noisebridge_prometheus_password_hash }}
+		}
+		metrics
+	}
+	{{ noisebridge_caddy_cadvisor_route }}
+	respond "Noisebridge Infrastructure - {{ ansible_fqdn }}"
 }
 
 library.noisebridge.net {
-  log {
-    output file "{{ caddy_log_dir }}/library.noisebridge.net.log" {
-      {{ noisebridge_caddy_log_roll | indent(width=6) }}
-    }
-    {{ noisebridge_caddy_log_filter | indent(width=4) }}
-  }
-  {{ noisebridge_caddy_secure_header | indent(width=2) }}
-  reverse_proxy localhost:5000
+	log {
+		output file "{{ caddy_log_dir }}/library.noisebridge.net.log" {
+			{{ noisebridge_caddy_log_roll }}
+		}
+		{{ noisebridge_caddy_log_filter }}
+	}
+	{{ noisebridge_caddy_secure_header }}
+	reverse_proxy localhost:5000
 }
+
 parts.noisebridge.net {
-  log {
-    output file "{{ caddy_log_dir }}/parts.noisebridge.net.log" {
-      {{ noisebridge_caddy_log_roll | indent(width=6) }}
-    }
-    {{ noisebridge_caddy_log_filter | indent(width=4) }}
-  }
-  {{ noisebridge_caddy_secure_header | indent(width=2) }}
-  reverse_proxy localhost:3000
+	log {
+		output file "{{ caddy_log_dir }}/parts.noisebridge.net.log" {
+			{{ noisebridge_caddy_log_roll }}
+		}
+		{{ noisebridge_caddy_log_filter }}
+	}
+	{{ noisebridge_caddy_secure_header }}
+	reverse_proxy localhost:3000
 }


### PR DESCRIPTION
The m6 webserver doesn't use the caddy-security plugin, don't include the config for it.

Use tabs to indent Caddyfile templates. This makes `caddy fmt` happy.