### PR TITLE
Fix Postfix TLS cert

### DIFF
--- a/group_vars/m5_noisebridge_net/prometheus.yml
+++ b/group_vars/m5_noisebridge_net/prometheus.yml
@@ -141,8 +141,8 @@ prometheus_scrape_configs:
       module: [smtp_starttls_v4]
     static_configs:
       - targets:
-          - noisebridge.net:25
-          - noisebridge.net:587
+          - m3.noisebridge.net:25
+          - m3.noisebridge.net:587
     relabel_configs: "{{ prometheus_blackbox_relabel_configs }}"
   - job_name: blackbox_smtp_v6
     metrics_path: /probe
@@ -150,8 +150,8 @@ prometheus_scrape_configs:
       module: [smtp_starttls_v6]
     static_configs:
       - targets:
-          - noisebridge.net:25
-          - noisebridge.net:587
+          - m3.noisebridge.net:25
+          - m3.noisebridge.net:587
     relabel_configs: "{{ prometheus_blackbox_relabel_configs }}"
   - job_name: grafana
     static_configs:

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -188,3 +188,9 @@
     - hashmaps
   notify:
     - postmap-hash
+
+- name: Add postfix to ssl-cert group for TLS listening
+  ansible.builtin.user:
+    name: postfix
+    groups: ssl-cert
+    append: true

--- a/roles/postfix/templates/main.cf
+++ b/roles/postfix/templates/main.cf
@@ -18,11 +18,9 @@ append_dot_mydomain = no
 readme_directory = no
 
 # TLS parameters
-# smtpd_tls_cert_file=/etc/postfix/noisebridge.net-cert.pem
-# smtpd_tls_key_file=/etc/postfix/noisebridge.net-key.pem
 smtpd_use_tls = yes
-smtpd_tls_cert_file=/home/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/m3.noisebridge.net/m3.noisebridge.net.crt
-smtpd_tls_key_file=/home/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/m3.noisebridge.net/m3.noisebridge.net.key
+smtpd_tls_cert_file=/etc/ssl/{{ postfix_mailname }}/{{ postfix_mailname }}.crt
+smtpd_tls_key_file=/etc/ssl/{{ postfix_mailname }}/{{ postfix_mailname }}.key
 smtpd_tls_ciphers = high
 smtpd_tls_exclude_ciphers = EXP, MEDIUM, LOW, DES, 3DES, SSLv2
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1


### PR DESCRIPTION
Fix the Postfix TLS by using the letsencrypt key setup by the `caddy` role.
* Add postfix to the ssl-cert group to access the key.
* Update monitoring probes to use the TLS hostname.