### PR TITLE
wiki_dumps: fix cron log permissions, run initial dump on deploy

### DIFF
--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -28,13 +28,13 @@
     owner: root
     group: root
 
-- name: Create dump log file with correct ownership
+- name: Create mediawiki log directory
   ansible.builtin.file:
-    path: /var/log/wiki_dump.log
-    state: touch
+    path: /var/log/mediawiki
+    state: directory
     owner: "{{ mediawiki.system_user }}"
     group: "{{ mediawiki.system_group }}"
-    mode: "0644"
+    mode: "0755"
 
 - name: Install cron job
   ansible.builtin.cron:
@@ -49,7 +49,7 @@
       PUBLIC_DIR={{ wiki_dumps_public_dir }}
       PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
       PHP=/usr/bin/php8.2
-      /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1
+      /usr/local/sbin/wiki_dump >> /var/log/mediawiki/wiki_dump.log 2>&1
 
 - name: Check if latest dump exists
   ansible.builtin.stat:

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -65,5 +65,6 @@
     PUBLIC_DIR: "{{ wiki_dumps_public_dir }}"
     PUBLIC_KEEP_DAYS: "{{ wiki_dumps_public_keep_days }}"
     PHP: /usr/bin/php8.2
+  become: true
   become_user: "{{ mediawiki.system_user }}"
   when: not latest_dump.stat.exists

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -28,6 +28,14 @@
     owner: root
     group: root
 
+- name: Create dump log file with correct ownership
+  ansible.builtin.file:
+    path: /var/log/wiki_dump.log
+    state: touch
+    owner: "{{ mediawiki.system_user }}"
+    group: "{{ mediawiki.system_group }}"
+    mode: "0644"
+
 - name: Install cron job
   ansible.builtin.cron:
     name: MediaWiki public dump
@@ -42,3 +50,20 @@
       PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
       PHP=/usr/bin/php8.2
       /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1
+
+- name: Check if latest dump exists
+  ansible.builtin.stat:
+    path: "{{ wiki_dumps_public_dir }}/latest.xml.gz"
+  register: latest_dump
+
+- name: Run initial dump if latest.xml.gz does not exist
+  ansible.builtin.command:
+    cmd: /usr/local/sbin/wiki_dump
+  environment:
+    MEDIAWIKI_PATH: "{{ wiki_dumps_mediawiki_path }}"
+    LOCALSETTINGS: "{{ wiki_dumps_localsettings }}"
+    PUBLIC_DIR: "{{ wiki_dumps_public_dir }}"
+    PUBLIC_KEEP_DAYS: "{{ wiki_dumps_public_keep_days }}"
+    PHP: /usr/bin/php8.2
+  become_user: "{{ mediawiki.system_user }}"
+  when: not latest_dump.stat.exists


### PR DESCRIPTION
Fixes #527.

Logged into m3 and confirmed `/var/log/wiki_dump.log` does not exist. The cron job runs as the `wiki` user, which can't create files in `/var/log/`, so the shell redirect fails and the dump script never runs. Added a task to create `/var/log/mediawiki/` with the correct ownership and updated the cron job to log there instead.

Also added tasks to run the dump immediately on deploy if `latest.xml.gz` doesn't exist, so there's no wait until the next 2AM cron fire.

Not sure if this is correct -- diagnosis seems right but where these files should go is up for comment.