### PR TITLE
wiki_dumps: replace cron job with systemd timer

### DIFF
--- a/roles/wiki_dumps/defaults/main.yml
+++ b/roles/wiki_dumps/defaults/main.yml
@@ -6,6 +6,6 @@ wiki_dumps_localsettings: "/srv/mediawiki/{{ mediawiki.domain }}/LocalSettings.p
 wiki_dumps_public_dir: /var/www/dumps.noisebridge.net
 wiki_dumps_public_keep_days: 7
 
-# Cron schedule (default: 2AM daily)
+# Timer schedule (default: 2AM daily)
 wiki_dumps_cron_hour: 2
 wiki_dumps_cron_minute: 0

--- a/roles/wiki_dumps/handlers/main.yml
+++ b/roles/wiki_dumps/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/roles/wiki_dumps/tasks/main.yml
+++ b/roles/wiki_dumps/tasks/main.yml
@@ -35,17 +35,38 @@
     owner: root
     group: root
 
-- name: Install cron job
-  ansible.builtin.cron:
-    name: MediaWiki public dump
-    cron_file: wiki_dump
-    user: "{{ mediawiki.system_user }}"
-    hour: "{{ wiki_dumps_cron_hour }}"
-    minute: "{{ wiki_dumps_cron_minute }}"
-    job: >-
-      MEDIAWIKI_PATH={{ wiki_dumps_mediawiki_path }}
-      LOCALSETTINGS={{ wiki_dumps_localsettings }}
-      PUBLIC_DIR={{ wiki_dumps_public_dir }}
-      PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
-      PHP=/usr/bin/php8.2
-      /usr/local/sbin/wiki_dump >> /var/log/wiki_dump.log 2>&1
+- name: Deploy systemd service unit
+  ansible.builtin.template:
+    src: wiki_dump.service.j2
+    dest: /etc/systemd/system/wiki_dump.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Deploy systemd timer unit
+  ansible.builtin.template:
+    src: wiki_dump.timer.j2
+    dest: /etc/systemd/system/wiki_dump.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable and start timer
+  ansible.builtin.systemd:
+    name: wiki_dump.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Check if latest dump exists
+  ansible.builtin.stat:
+    path: "{{ wiki_dumps_public_dir }}/latest.xml.gz"
+  register: latest_dump
+
+- name: Run initial dump if latest.xml.gz does not exist
+  ansible.builtin.systemd:
+    name: wiki_dump.service
+    state: started
+  when: not latest_dump.stat.exists

--- a/roles/wiki_dumps/templates/wiki_dump.service.j2
+++ b/roles/wiki_dumps/templates/wiki_dump.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=MediaWiki public dump
+After=network.target mysql.service
+
+[Service]
+Type=oneshot
+User={{ mediawiki.system_user }}
+Group={{ mediawiki.system_group }}
+Environment=MEDIAWIKI_PATH={{ wiki_dumps_mediawiki_path }}
+Environment=LOCALSETTINGS={{ wiki_dumps_localsettings }}
+Environment=PUBLIC_DIR={{ wiki_dumps_public_dir }}
+Environment=PUBLIC_KEEP_DAYS={{ wiki_dumps_public_keep_days }}
+Environment=PHP=/usr/bin/php8.2
+ExecStart=/usr/local/sbin/wiki_dump

--- a/roles/wiki_dumps/templates/wiki_dump.timer.j2
+++ b/roles/wiki_dumps/templates/wiki_dump.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=MediaWiki public dump timer
+
+[Timer]
+OnCalendar=*-*-* {{ wiki_dumps_cron_hour | int }}:{{ wiki_dumps_cron_minute | int }}:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Alternative fix for #527, parallel to #528 — replace the cron job with a systemd service + timer.

Advantages over the cron approach:
- Logs go to the journal via stdout, no log file ownership problem
- Timer status and last-run time visible via `systemctl status wiki_dump.timer`
- `Persistent=true` catches up a missed run if the machine was down at 2AM
- Cgroup metrics and runtime tracking come for free

The service unit runs as the mediawiki user directly, with environment variables set in the unit rather than inline in the cron job. The timer preserves the same 2AM schedule and uses the same `wiki_dumps_cron_hour`/`wiki_dumps_cron_minute` variables.

Also runs the dump immediately on deploy if `latest.xml.gz` doesn't exist, same as #528.

Opening alongside #528 so others can weigh in on which approach to take.