### PR TITLE
Fix wikidump script

### DIFF
--- a/roles/wiki_dumps/files/wiki_dump.sh
+++ b/roles/wiki_dumps/files/wiki_dump.sh
@@ -20,7 +20,7 @@ OUTFILE="${PUBLIC_DIR}/noisebridge-${TS}-public.xml.gz"
 echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] Starting public dump -> ${OUTFILE}"
 "${PHP}" "${MEDIAWIKI_PATH}/maintenance/dumpBackup.php" \
   --conf "${LOCALSETTINGS}" \
-  --current --public \
+  --current \
   --output "gzip:${OUTFILE}.tmp"
 mv "${OUTFILE}.tmp" "${OUTFILE}"
 ln -sf "${OUTFILE}" "${PUBLIC_DIR}/latest.xml.gz"


### PR DESCRIPTION
There doesn't seem to be a `--public` flag to the mediawiki dump tool[0].

0: https://www.mediawiki.org/wiki/Manual:DumpBackup.php