### PR TITLE
anubis: add impressum footer linking to wiki dumps

### DIFF
--- a/roles/anubis/templates/policy.yaml.j2
+++ b/roles/anubis/templates/policy.yaml.j2
@@ -12,6 +12,25 @@
 #     username: "{{ anubis_metrics_username }}"
 #     password: "{{ anubis_metrics_password }}"
 
+impressum:
+  # Footer shown on every Anubis challenge/deny page — points bots to the dump.
+  footer: >-
+    Looking for bulk wiki content?
+    <a href="https://dumps.noisebridge.net">Download the full wiki dump</a> instead of scraping.
+  page:
+    title: "Noisebridge Wiki — Bot & Scraper Policy"
+    body: >-
+      <p>The <a href="https://www.noisebridge.net">Noisebridge wiki</a> is protected
+      by <a href="https://anubis.techaro.lol">Anubis</a> to prevent scraper bots
+      from overloading the server.</p>
+
+      <p>If you are a bulk data consumer or AI training pipeline, please use the
+      <a href="https://dumps.noisebridge.net">public wiki dump</a> instead of
+      scraping live pages. The dump is updated daily and is free to use.</p>
+
+      <p>If you believe you have been incorrectly challenged, contact
+      <a href="mailto:{{ anubis_webmaster_email }}">{{ anubis_webmaster_email }}</a>.</p>
+
 store:
   backend: bbolt
   parameters:

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -119,43 +119,6 @@ www.noisebridge.net {
   }
   {{ noisebridge_caddy_secure_header | indent(width=2) }}
 
-  # Named AI/bulk crawlers: redirect to wiki dumps before they hit Anubis.
-  # These UAs are identifiable bulk scrapers — better to route them to the
-  # structured dump than wall them off with a challenge they can't solve.
-  # Source: https://github.com/noisebridge/noisebridge-wiki/issues/10
-  @dump_crawlers {
-    header User-Agent *GPTBot*
-    header User-Agent *OAI-SearchBot*
-    header User-Agent *ChatGPT-User*
-    header User-Agent *ClaudeBot*
-    header User-Agent *Claude-SearchBot*
-    header User-Agent *Claude-User*
-    header User-Agent *Claude-Web*
-    header User-Agent *anthropic-ai*
-    header User-Agent *CCBot*
-    header User-Agent *Bytespider*
-    header User-Agent *Amazonbot*
-    header User-Agent *cohere-ai*
-    header User-Agent *cohere-training-data-crawler*
-    header User-Agent *PerplexityBot*
-    header User-Agent *Perplexity-User*
-    header User-Agent *FacebookBot*
-    header User-Agent *meta-externalagent*
-    header User-Agent *Meta-ExternalAgent*
-    header User-Agent *meta-externalfetcher*
-    header User-Agent *Meta-ExternalFetcher*
-    header User-Agent *Diffbot*
-    header User-Agent *AI2Bot*
-    header User-Agent *Ai2Bot-Dolma*
-    header User-Agent *ImagesiftBot*
-    header User-Agent *DuckAssistBot*
-    header User-Agent *FriendlyCrawler*
-    header User-Agent *YouBot*
-    header User-Agent *TikTokSpider*
-    header User-Agent *PetalBot*
-  }
-  redir @dump_crawlers https://dumps.noisebridge.net 302
-
   # Anubis challenge assets (served directly from Anubis)
   handle /.within.website/* {
     reverse_proxy unix//run/anubis/anubis.sock {

--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -119,6 +119,43 @@ www.noisebridge.net {
   }
   {{ noisebridge_caddy_secure_header | indent(width=2) }}
 
+  # Named AI/bulk crawlers: redirect to wiki dumps before they hit Anubis.
+  # These UAs are identifiable bulk scrapers — better to route them to the
+  # structured dump than wall them off with a challenge they can't solve.
+  # Source: https://github.com/noisebridge/noisebridge-wiki/issues/10
+  @dump_crawlers {
+    header User-Agent *GPTBot*
+    header User-Agent *OAI-SearchBot*
+    header User-Agent *ChatGPT-User*
+    header User-Agent *ClaudeBot*
+    header User-Agent *Claude-SearchBot*
+    header User-Agent *Claude-User*
+    header User-Agent *Claude-Web*
+    header User-Agent *anthropic-ai*
+    header User-Agent *CCBot*
+    header User-Agent *Bytespider*
+    header User-Agent *Amazonbot*
+    header User-Agent *cohere-ai*
+    header User-Agent *cohere-training-data-crawler*
+    header User-Agent *PerplexityBot*
+    header User-Agent *Perplexity-User*
+    header User-Agent *FacebookBot*
+    header User-Agent *meta-externalagent*
+    header User-Agent *Meta-ExternalAgent*
+    header User-Agent *meta-externalfetcher*
+    header User-Agent *Meta-ExternalFetcher*
+    header User-Agent *Diffbot*
+    header User-Agent *AI2Bot*
+    header User-Agent *Ai2Bot-Dolma*
+    header User-Agent *ImagesiftBot*
+    header User-Agent *DuckAssistBot*
+    header User-Agent *FriendlyCrawler*
+    header User-Agent *YouBot*
+    header User-Agent *TikTokSpider*
+    header User-Agent *PetalBot*
+  }
+  redir @dump_crawlers https://dumps.noisebridge.net 302
+
   # Anubis challenge assets (served directly from Anubis)
   handle /.within.website/* {
     reverse_proxy unix//run/anubis/anubis.sock {


### PR DESCRIPTION
Adds an Anubis impressum footer pointing to `dumps.noisebridge.net` on every challenge/deny page. Useful for headless browsers and bots that make it past the Caddy layer.

Noisebridge wants wiki content indexed by LLMs, so we're not redirecting or blocking AI crawlers — the `ai-block-permissive` Anubis policy is intentional. The dump is an alternative for bulk consumers who prefer structured data.

Closes noisebridge/noisebridge-wiki#10