### PR TITLE
Forwards noisebridge.io zone to Hetzner NS for testing.

### DIFF
--- a/files/coredns/zones/noisebridge.io
+++ b/files/coredns/zones/noisebridge.io
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.io. IN SOA helium.ns.hetzner.de. hostmaster.noisebridge.io. (
-        2026033000 ; Serial
+        2026060900 ; Serial
         3600 ; Refresh
         300 ; Retry
         604800 ; Expire

--- a/files/coredns/zones/noisebridge.io
+++ b/files/coredns/zones/noisebridge.io
@@ -3,7 +3,7 @@
 
 $TTL 3600
 
-noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridge.io.  (
+noisebridge.io. IN SOA helium.ns.hetzner.de. hostmaster.noisebridge.io. (
         2026033000 ; Serial
         3600 ; Refresh
         300 ; Retry
@@ -11,27 +11,30 @@ noisebridge.io.        IN      SOA     ns.noisebridge.net. hostmaster.noisebridg
         300 ) ; Minimum
 
 ; name server records
-@               IN      NS      ns1.noisebridge.net.
-@               IN      NS      ns2.noisebridge.net.
+@               IN      NS      helium.ns.hetzner.de.
+@               IN      NS      hydrogen.ns.hetzner.com.
+@               IN      NS      oxygen.ns.hetzner.com.
+;@               IN      NS      ns1.noisebridge.net.
+;@               IN      NS      ns2.noisebridge.net.
 
-; hostnameless access
-@       300     IN      A       216.252.162.220
-@       300     IN      AAAA    2602:ff06:725:5:dc::1337
+; The following records have been manually copied to Hetzner while
+; we figure out how to best programatically control CoreDNS.
 
-; SPF
-@       86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
+; ; hostnameless access
+;@       300     IN      A       216.252.162.220
+;@       300     IN      AAAA    2602:ff06:725:5:dc::1337
 
-; subdomains
-barnyard        86400   IN      NS      brony.noisebridge.io.
+; ; SPF
+;@       86400   IN      TXT     "v=spf1 redirect=spf.noisebridge.net"
 
-; aliases
-blog            10800   IN      CNAME   blogs.vip.gandi.net.
-brony           1800    IN      A       199.241.139.224
-cia             1800    IN      A       199.188.195.8
-cycletrailer    1800    IN      CNAME   cycletrailer.noisebridge.net.
-jitsi           1800    IN      A       199.188.195.96
-pegasus         1800    IN      CNAME   pegasus.noisebridge.net.
-share           1800    IN      A       199.188.195.78
-webmail         10800   IN      CNAME   webmail.gandi.net.
-www             10800   IN      CNAME   m3.noisebridge.net.
-zeppelin        1800    IN      CNAME   zeppelin.noisebridge.net.
+; Note: The majority of services below are currently offline but
+; are kept for posterity.
+
+; ; subdomains
+;barnyard        86400   IN      NS      brony.noisebridge.io.
+
+; ; aliases
+;brony           1800    IN      A       199.241.139.224
+;pegasus         1800    IN      CNAME   pegasus.noisebridge.net.
+;webmail         10800   IN      CNAME   webmail.gandi.net.
+;www             10800   IN      CNAME   m3.noisebridge.net.


### PR DESCRIPTION
Points `noisebridge.io` zone to Hetzner's nameservers for bare-metal k8s test. 

Also cleaned up some deprecated services. Migrated some that have a reasonable chance to be brought back online.