### PR TITLE
Add ansible comment to wiki_dumps index

### DIFF
--- a/roles/wiki_dumps/templates/index.html.j2
+++ b/roles/wiki_dumps/templates/index.html.j2
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{{ ansible_managed | comment('xml') }}
 <html lang="en">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
Add an "Ansible managed" comment to the dumps.noisebridge.net index.html so it's marked that it's a template.