### PR TITLE
caddy/m3: trust 127.0.0.1 as a proxy for X-Forwarded-* handling

### DIFF
--- a/templates/caddy/m3/Caddyfile.j2
+++ b/templates/caddy/m3/Caddyfile.j2
@@ -5,6 +5,10 @@
 
 	{{ noisebridge_caddy_global_security }}
 	{{ noisebridge_caddy_global_metrics }}
+
+	servers {
+		trusted_proxies static 127.0.0.1
+	}
 }
 
 # Internal MediaWiki backend (used by Anubis)


### PR DESCRIPTION
Add a global `servers { trusted_proxies static 127.0.0.1 }` block to the m3 Caddyfile.

On m3, requests pass through a localhost proxy chain:

    Internet → Caddy :443 → Anubis (unix socket) → Caddy :8080 → PHP-FPM

At each hop Caddy sets X-Real-IP / X-Forwarded-For / X-Forwarded-Proto from {remote_host} and {scheme} so the real client IP and scheme survive the chain. But since Caddy 2.7, X-Forwarded-* headers are only honored when the immediate peer is a *trusted* proxy; from any untrusted source they are ignored to prevent client-IP spoofing. Because the inner hops arrive over loopback, Caddy treats them as untrusted by default and the :8080 backend sees every request as coming from 127.0.0.1 — breaking access logging, geoip, and any IP-based rate limiting.

Declaring 127.0.0.1 as a trusted proxy tells Caddy to read the real client IP and scheme from the forwarded headers on loopback hops instead of falling back to the connecting address. The scope is deliberately narrow — only loopback is trusted, so externally-supplied X-Forwarded-For headers are still discarded.

Fixes #504
Fixes #543