### PR TITLE
Moves donate.noisebridge.net from being hosted on render.com to noisegarden-root (k8s cluster on Hetzner VPS)

### DIFF
--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -234,7 +234,7 @@ upotagma        IN      AAAA    2604:a880:1:20:0:0:c3:a001
 ; * Use the provided credentials to self-provision a letsEncrypt cert.
 ;
 ; Note: We currently use auth.acme-dns.io but we can also self-host this service.
-
+_acme-challenge             IN      CNAME   f025e3fe-fbc8-4d3d-8d4f-cb8a2ac38f5e.auth.acme-dns.io.
 _acme-challenge.colossus    IN      CNAME   16c8a8b7-44cc-4c18-8c43-0ae57d21b118.auth.acme-dns.io.
 _acme-challenge.ducky       IN      CNAME   331d1498-d188-4fea-935c-7b2a225f684a.auth.acme-dns.io.
 _acme-challenge.garden      IN      CNAME   89d749fd-a9c9-40f7-94e1-2c3cb32ec5c2.auth.acme-dns.io.

--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026071701 ; Serial
+                                2026071700 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire

--- a/files/coredns/zones/noisebridge.net
+++ b/files/coredns/zones/noisebridge.net
@@ -4,7 +4,7 @@
 $TTL 3600
 
 noisebridge.net.        IN      SOA     ns1.noisebridge.net. hostmaster.noisebridge.net.  (
-                                2026061701 ; Serial
+                                2026071701 ; Serial
                                 3600 ; Refresh
                                 300 ; Retry
                                 604800 ; Expire
@@ -170,10 +170,12 @@ safespace       IN      CNAME   m3
 
 ; Services hosted on m5
 alertmanager    IN      CNAME   m5
-donate          IN      CNAME   donate-noisebridge-net.onrender.com.
 grafana         IN      CNAME   m5
 prometheus      IN      CNAME   m5
 test-safespace  IN      CNAME   m5
+
+; Services hosted on noisegarden-root (Hetzner VPS)
+donate          IN      A       204.168.192.161
 
 ; donate.noisebridge.net email records (resend.com)
 resend._domainkey.donate  IN  TXT  "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCoQWXGT4XLCErI5+ILqqMcSybWz1DxAqGyw9cxuaPN39YIyD6+SsvoP0p83iX3appGI4EXAVXe2YNPmNaa9UBnG7eio0tUe61L/J/82XEV/XbYTZpCGE5laIbQWZh77BBD9Ie6RpmYW2p1frnSUuz6BmnsT63fCToPfVU8K3jC/wIDAQAB"


### PR DESCRIPTION
Tested @ https://donate.noisegarden.nexus